### PR TITLE
Remove all lines with svn keywords

### DIFF
--- a/motorApp/AcsSrc/AcsRegister.cc
+++ b/motorApp/AcsSrc/AcsRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	AcsRegister.cc
 USAGE...	Register ACS motor device driver shell commands.
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:06:58 $
 */
 
 /*****************************************************************

--- a/motorApp/AcsSrc/AcsRegister.h
+++ b/motorApp/AcsSrc/AcsRegister.h
@@ -2,9 +2,6 @@
 FILENAME...	AcsRegister.h
 USAGE... This file contains function prototypes for ACS IOC shell commands.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:06:58 $
 */
 
 /*

--- a/motorApp/AcsTech80Src/ACSTech80Register.cc
+++ b/motorApp/AcsTech80Src/ACSTech80Register.cc
@@ -2,9 +2,6 @@
 FILENAME...	ACSTech80Register.cc
 USAGE...	Register ACS Tech80 motor device driver shell commands.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2008-05-21 21:18:52 $
 */
 
 /*****************************************************************

--- a/motorApp/AcsTech80Src/devSPiiPlus.cc
+++ b/motorApp/AcsTech80Src/devSPiiPlus.cc
@@ -2,9 +2,6 @@
 FILENAME...	devSPiiPlus.cc
 USAGE...	Motor record device level support for ACS Tech80 SPiiPlus
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2008-05-21 21:18:52 $
 */
 
 /*

--- a/motorApp/AcsTech80Src/drvSPiiPlus.cc
+++ b/motorApp/AcsTech80Src/drvSPiiPlus.cc
@@ -3,10 +3,6 @@ FILENAME...	drvSPiiPlus.cc
 USAGE...	Motor record driver level support for ACS Tech80 
                 SPiiPlus
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 
 */
 

--- a/motorApp/AcsTech80Src/drvSPiiPlus.h
+++ b/motorApp/AcsTech80Src/drvSPiiPlus.h
@@ -3,9 +3,6 @@ FILENAME...	drvSPiiPlus.h
 USAGE...    This file contains ACS Tech80 driver "include"
 	    information that is specific to the SPiiPlus serial controller
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2008-05-21 21:18:53 $
 
 */
 

--- a/motorApp/AerotechSrc/AerotechRegister.cc
+++ b/motorApp/AerotechSrc/AerotechRegister.cc
@@ -2,10 +2,6 @@
 FILENAME...	AerotechRegister.cc
 USAGE...	Register Aerotech motor device driver shell commands.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*****************************************************************

--- a/motorApp/AerotechSrc/AerotechRegister.h
+++ b/motorApp/AerotechSrc/AerotechRegister.h
@@ -2,10 +2,6 @@
 FILENAME...	AerotechRegister.h
 USAGE... This file contains function prototypes for ACS IOC shell commands.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/AerotechSrc/devSoloist.cc
+++ b/motorApp/AerotechSrc/devSoloist.cc
@@ -2,10 +2,6 @@
 * FILENAME... devSoloist.cc
 * USAGE... Motor record device level support for Aerotech Soloist.
 *
-* Version:        $Revision$
-* Modified By:    $Author$
-* Last Modified:  $Date$
-* HeadURL:        $URL$
 *
 */
 

--- a/motorApp/AerotechSrc/drvA3200Asyn.cc
+++ b/motorApp/AerotechSrc/drvA3200Asyn.cc
@@ -2,10 +2,6 @@
 FILENAME... drvA3200Asyn.cc
 USAGE...    Motor record asyn driver level support for Aerotech A3200.
  
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$ 
 */
 
 /*

--- a/motorApp/AerotechSrc/drvA3200Asyn.h
+++ b/motorApp/AerotechSrc/drvA3200Asyn.h
@@ -2,10 +2,6 @@
 FILENAME...     drvA3200Asyn.h
 USAGE... This file contains Aerotech A3200 Asyn driver "include" information.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/AerotechSrc/drvEnsembleAsyn.cc
+++ b/motorApp/AerotechSrc/drvEnsembleAsyn.cc
@@ -2,10 +2,6 @@
 FILENAME... drvEnsembleAsyn.cc
 USAGE...    Motor record asyn driver level support for Aerotech Ensemble.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/AerotechSrc/drvEnsembleAsyn.h
+++ b/motorApp/AerotechSrc/drvEnsembleAsyn.h
@@ -2,10 +2,6 @@
 FILENAME...     drvEnsembleAsyn.h
 USAGE... This file contains Aerotech Ensemble Asyn driver "include" information.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/AerotechSrc/drvSoloist.cc
+++ b/motorApp/AerotechSrc/drvSoloist.cc
@@ -2,10 +2,6 @@
 * FILENAME... drvSoloist.cc
 * USAGE...    Motor record driver level support for Aerotech Soloist.
 *
-* Version:        $Revision$
-* Modified By:    $Author$
-* Last Modified:  $Date$
-* HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/AerotechSrc/drvSoloist.h
+++ b/motorApp/AerotechSrc/drvSoloist.h
@@ -2,10 +2,6 @@
 FILENAME...	drvSoloist.h
 USAGE... This file contains Aerotech Soloist driver "include" information.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/AttocubeSrc/drvANC150Asyn.cc
+++ b/motorApp/AttocubeSrc/drvANC150Asyn.cc
@@ -3,9 +3,6 @@ FILENAME...     drvANC150Asyn.cc
 USAGE...        asyn motor driver support for attocube systems AG ANC150
                 Piezo Step Controller.
 
-Version:        $Revision: 1.9 $
-Modified By:    $Author: sluiter $
-Last Modified:  $Date: 2009-08-13 20:05:24 $
 
 */
 

--- a/motorApp/Db/asyn_motor_settings.req
+++ b/motorApp/Db/asyn_motor_settings.req
@@ -1,8 +1,4 @@
 # FILE... motor_settings.req
-# Version:        $Revision$
-# Modified By:    $Author$
-# Last Modified:  $Date$
-# HeadURL:        $URL$
 
 file basic_motor_settings.req P=$(P),M=$(M)
 $(P)$(M)_able.VAL

--- a/motorApp/Db/basic_motor_settings.req
+++ b/motorApp/Db/basic_motor_settings.req
@@ -1,8 +1,4 @@
 # FILE... basic_motor_settings.req
-# Version:        $Revision$
-# Modified By:    $Author$
-# Last Modified:  $Date$
-# HeadURL:        $URL$
 
 $(P)$(M).DIR
 $(P)$(M).DHLM

--- a/motorApp/Db/motor_settings.req
+++ b/motorApp/Db/motor_settings.req
@@ -1,8 +1,4 @@
 # FILE... motor_settings.req
-# Version:        $Revision$
-# Modified By:    $Author$
-# Last Modified:  $Date$
-# HeadURL:        $URL$
 
 file basic_motor_settings.req P=$(P),M=$(M)
 $(P)$(M)_able.VAL

--- a/motorApp/DeltaTauSrc/devPmac.cc
+++ b/motorApp/DeltaTauSrc/devPmac.cc
@@ -2,9 +2,6 @@
 FILENAME...	devPmac.cc
 USAGE... Device level support for Delta Tau PMAC.
 
-Version:	$Revision: 1.5 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:09:01 $
 */
 
 /*

--- a/motorApp/DeltaTauSrc/drvPmac.cc
+++ b/motorApp/DeltaTauSrc/drvPmac.cc
@@ -2,9 +2,6 @@
 FILENAME...	drvPmac.cc
 USAGE...	Driver level support for Delta Tau PMAC model.
 
-Version:	$Revision: 1.11 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2009-09-08 18:25:19 $
 */
 
 /*

--- a/motorApp/DeltaTauSrc/drvPmac.h
+++ b/motorApp/DeltaTauSrc/drvPmac.h
@@ -2,9 +2,6 @@
 FILENAME...	drvPmac.h
 USAGE... This file contains Delta Tau PMAC driver "include" information.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2009-05-01 18:26:29 $
 */
 
 /*

--- a/motorApp/FaulhaberSrc/devMCDC2805.cc
+++ b/motorApp/FaulhaberSrc/devMCDC2805.cc
@@ -3,9 +3,6 @@ FILENAME...	devMCDC2805.cc
 USAGE...	Motor record device level support for Intelligent Motion
 		Systems, Inc. MCDC2805 series of controllers.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:09:24 $
 */
 
 /*

--- a/motorApp/FaulhaberSrc/drvMCDC2805.cc
+++ b/motorApp/FaulhaberSrc/drvMCDC2805.cc
@@ -2,11 +2,6 @@
 FILENAME... drvMCDC2805.cc
 USAGE...    Motor record driver level support for Faulhaber MCDC2805
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
-Last Modified:  $Date$
 */
 
 /*

--- a/motorApp/FaulhaberSrc/drvMCDC2805.h
+++ b/motorApp/FaulhaberSrc/drvMCDC2805.h
@@ -2,9 +2,6 @@
 FILENAME...	drvMCDC2805.h
 USAGE... This file contains driver "include" information for the Faulhaber MCDC 2805 controller.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: rivers $
-Last Modified:	$Date: 2005-11-04 23:05:35 $
 */
 
 /*

--- a/motorApp/ImsSrc/ImsRegister.cc
+++ b/motorApp/ImsSrc/ImsRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	ImsRegister.cc
 USAGE...	Register IMS motor device driver shell commands.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:10:15 $
 */
 
 /*****************************************************************

--- a/motorApp/ImsSrc/devIM483PL.cc
+++ b/motorApp/ImsSrc/devIM483PL.cc
@@ -3,10 +3,6 @@ FILENAME...	devIM483PL.cc
 USAGE...	Motor record device level support for Intelligent Motion
 		Systems, Inc. IM483(I/IE).
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
-HeadURL:	$URL$
 */
 
 /*

--- a/motorApp/ImsSrc/devIM483SM.cc
+++ b/motorApp/ImsSrc/devIM483SM.cc
@@ -3,10 +3,6 @@ FILENAME...	devIM483SM.cc
 USAGE...	Motor record device level support for Intelligent Motion
 		Systems, Inc. IM483(I/IE).
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
-HeadURL:	$URL$
 */
 
 /*

--- a/motorApp/ImsSrc/devMDrive.cc
+++ b/motorApp/ImsSrc/devMDrive.cc
@@ -3,10 +3,6 @@ FILENAME...	devMDrive.cc
 USAGE...	Motor record device level support for Intelligent Motion
 		Systems, Inc. MDrive series of controllers.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
-HeadURL:	$URL$
 */
 
 /*

--- a/motorApp/ImsSrc/drvIM483.h
+++ b/motorApp/ImsSrc/drvIM483.h
@@ -3,10 +3,6 @@ FILENAME...	drvIM483.h
 USAGE... This file contains driver "include" information that is specific to
 	Intelligent Motion Systems, Inc. IM483(I/IE) and MDrive controllers.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$ 
-HeadURL:	$URL$ 
 */
 
 /*

--- a/motorApp/ImsSrc/drvIM483PL.cc
+++ b/motorApp/ImsSrc/drvIM483PL.cc
@@ -3,10 +3,6 @@ FILENAME... drvIM483PL.cc
 USAGE...    Motor record driver level support for Intelligent Motion
         Systems, Inc. IM483(I/IE).
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*****************************************************************

--- a/motorApp/ImsSrc/drvIM483SM.cc
+++ b/motorApp/ImsSrc/drvIM483SM.cc
@@ -3,10 +3,6 @@ FILENAME... drvIM483SM.cc
 USAGE...    Motor record driver level support for Intelligent Motion
         Systems, Inc. IM483(I/IE).
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*****************************************************************

--- a/motorApp/ImsSrc/drvMDrive.cc
+++ b/motorApp/ImsSrc/drvMDrive.cc
@@ -3,10 +3,6 @@ FILENAME... drvMDrive.cc
 USAGE...    Motor record driver level support for Intelligent Motion
             Systems, Inc. MDrive series; M17, M23, M34.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/KohzuSrc/devSC800.cc
+++ b/motorApp/KohzuSrc/devSC800.cc
@@ -2,10 +2,6 @@
 FILENAME...     devSC800.cc
 USAGE...        Motor record device level support for Kohzu SC800 motor controller.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 
 */
 

--- a/motorApp/KohzuSrc/drvSC800.cc
+++ b/motorApp/KohzuSrc/drvSC800.cc
@@ -2,10 +2,6 @@
 FILENAME...     drvSC800.cc
 USAGE...        Motor record driver level support for Kohzu SC800                
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 
 */
 

--- a/motorApp/KohzuSrc/drvSC800.h
+++ b/motorApp/KohzuSrc/drvSC800.h
@@ -2,10 +2,6 @@
 FILENAME...	drvSC800.h
 USAGE...    This file contains Kohzu SC800 motorRecord driver information.
 
-Version:	    $Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MXmotorSrc/MXRegister.cc
+++ b/motorApp/MXmotorSrc/MXRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	MXRegister.cc
 USAGE...	Register MX motor device driver shell commands.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2003-05-28 14:33:57 $
 */
 
 /*****************************************************************

--- a/motorApp/MXmotorSrc/MXmotor.h
+++ b/motorApp/MXmotorSrc/MXmotor.h
@@ -3,9 +3,6 @@ FILENAME...	MXmotor.h
 USAGE... This file contains "include" information that is specific to
 	MX motor device driver support.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2003-02-14 15:15:27 $
 */
 
 /*

--- a/motorApp/MXmotorSrc/devMXmotor.cc
+++ b/motorApp/MXmotorSrc/devMXmotor.cc
@@ -2,9 +2,6 @@
 FILENAME...	devMXmotor.cc
 USAGE...	Motor record device level support for MX device driver.
 
-Version:	$Revision: 1.6 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:12:06 $
 */
 
 /*

--- a/motorApp/MXmotorSrc/drvMXmotor.cc
+++ b/motorApp/MXmotorSrc/drvMXmotor.cc
@@ -2,10 +2,6 @@
 FILENAME...	drvMXmotor.cc
 USAGE...	Motor record driver level support for MX device driver.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MclennanSrc/MclennanRegister.cc
+++ b/motorApp/MclennanSrc/MclennanRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	MclennanRegister.cc
 USAGE...	Register Mclennan motor device driver shell commands.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:17:22 $
 */
 
 /*****************************************************************

--- a/motorApp/MicosSrc/MicosRegister.cc
+++ b/motorApp/MicosSrc/MicosRegister.cc
@@ -2,9 +2,6 @@
 FILENAME... MicosRegister.cc
 USAGE...    Register Micos MoCo dc motor controller device driver shell commands.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:22:58 $
 */
 
 /*****************************************************************

--- a/motorApp/MicroMoSrc/MicroMoRegister.cc
+++ b/motorApp/MicroMoSrc/MicroMoRegister.cc
@@ -3,9 +3,6 @@ FILENAME... MicroMoRegister.cc
 USAGE...    Register MicroMo MVP 2001 B02 motor controller device driver shell
 	    commands.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:25:09 $
 */
 
 /*****************************************************************

--- a/motorApp/MicroMoSrc/devMVP2001.cc
+++ b/motorApp/MicroMoSrc/devMVP2001.cc
@@ -3,9 +3,6 @@ FILENAME...	devMVP2001.cc
 USAGE...	Motor record device level support for MicroMo
                 MVP 2001 B02 (Linear, RS-485).
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-06-06 17:16:51 $
 */
 
 /*

--- a/motorApp/MicroMoSrc/drvMVP2001.cc
+++ b/motorApp/MicroMoSrc/drvMVP2001.cc
@@ -3,9 +3,6 @@ FILENAME... drvMVP2001.cc
 USAGE...    Motor record driver level support for MicroMo
             MVP 2001 B02 (Linear, RS-485).
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
 */
 
 /*

--- a/motorApp/MicroMoSrc/drvMVP2001.h
+++ b/motorApp/MicroMoSrc/drvMVP2001.h
@@ -3,9 +3,6 @@ FILENAME...	drvMVP2001.h
 USAGE... This file contains driver "include" information that is specific to
 	 the MicroMo MVP 2001 B02 (Linear, RS-485).
 
-Version:	$Revision: 1.5 $
-Modified By:	$Author: rivers $
-Last Modified:	$Date: 2004-08-17 21:29:32 $
 */
 
 /*

--- a/motorApp/MotorSimSrc/drvMotorSim.c
+++ b/motorApp/MotorSimSrc/drvMotorSim.c
@@ -2,9 +2,6 @@
 FILENAME...	drvMotorSim.c
 USAGE...	Simulated Motor Support.
 
-Version:	$Revision: 1.10 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2009-06-18 19:38:20 $
 */
 
 /*

--- a/motorApp/MotorSrc/devMotorAsyn.c
+++ b/motorApp/MotorSrc/devMotorAsyn.c
@@ -11,9 +11,6 @@
  * Notwithstanding the above, explicit permission is granted for APS to 
  * redistribute this software.
  *
- * Version: $Revision: 1.32 $
- * Modified by: $Author: rivers $
- * Last Modified: $Date: 2009-09-01 14:05:38 $
  *
  * Original Author: Peter Denison
  * Current Author: Peter Denison

--- a/motorApp/MotorSrc/drvMotorAsyn.c
+++ b/motorApp/MotorSrc/drvMotorAsyn.c
@@ -19,9 +19,6 @@
  *     of this distribution.
  *     ************************************************************************
  *
- * Version: $Revision: 1.22 $
- * Modified by: $Author: rivers $
- * Last Modified: $Date: 2009-09-01 14:05:07 $
  *
  * Original Author: Peter Denison
  * Current Author: Peter Denison

--- a/motorApp/MotorSrc/motor.h
+++ b/motorApp/MotorSrc/motor.h
@@ -3,9 +3,6 @@ FILENAME...     motor.h
 USAGE...        Definitions and structures common to all levels of motorRecord
                 support (i.e., record, device and driver).
 
-Version:        $Revision: 1.21 $
-Modified By:    $Author: sluiter $
-Last Modified:  $Date: 2009-04-27 14:28:42 $
 */
 
 /*

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -2,10 +2,6 @@
 FILENAME...     motorRecord.cc
 USAGE...        Motor Record Support.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MotorSrc/motorRecord.dbd
+++ b/motorApp/MotorSrc/motorRecord.dbd
@@ -1,9 +1,5 @@
 # FILENAME...   motorRecord.dbd
 
-# Version:       $Revision$
-# Modified By:   $Author$
-# Last Modified: $Date$
-# HeadURL:       $URL$
 
 # Experimental Physics and Industrial Control System (EPICS)
 

--- a/motorApp/MotorSrc/motorUtil.cc
+++ b/motorApp/MotorSrc/motorUtil.cc
@@ -2,10 +2,6 @@
 FILENAME...     motorUtil.cc
 USAGE...        Motor Record Utility Support.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 

--- a/motorApp/MotorSrc/motorUtilAux.cc
+++ b/motorApp/MotorSrc/motorUtilAux.cc
@@ -2,10 +2,6 @@
 FILENAME...     motorUtilAux.cc
 USAGE...        Motor Record Utility Support.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MotorSrc/motordevCom.cc
+++ b/motorApp/MotorSrc/motordevCom.cc
@@ -3,10 +3,6 @@ FILENAME: motordevCom.cc
 USAGE... This file contains device functions that are common to all motor
     record device support modules.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MotorSrc/motordevCom.h
+++ b/motorApp/MotorSrc/motordevCom.h
@@ -3,10 +3,6 @@ FILENAME...	motordevCom.h
 USAGE...	This file contains definitions and structures that
 		are common to all motor record device support modules.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MotorSrc/motordrvCom.cc
+++ b/motorApp/MotorSrc/motordrvCom.cc
@@ -3,10 +3,6 @@ FILENAME...     motordrvCom.cc
 USAGE...        This file contains driver functions that are common
                 to all motor record driver modules.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MotorSrc/motordrvCom.h
+++ b/motorApp/MotorSrc/motordrvCom.h
@@ -4,10 +4,6 @@ FILENAME...	motordrvCom.h
 USAGE...	This file contains definitions and structures that
 		are common to all motor record driver support modules.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/MotorSrc/motordrvComCode.h
+++ b/motorApp/MotorSrc/motordrvComCode.h
@@ -4,10 +4,6 @@ USAGE... This file contains local variables that are allocated
 	in each motor record driver.  The variables are allocated
 	in each driver by including this file.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/NewportSrc/NewportRegister.cc
+++ b/motorApp/NewportSrc/NewportRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	NewportRegister.cc
 USAGE...	Register Newport motor device driver shell commands.
 
-Version:	$Revision: 1.13 $
-Modified By:	$Author: rivers $
-Last Modified:	$Date: 2006-06-15 19:02:59 $
 */
 
 /*****************************************************************

--- a/motorApp/NewportSrc/NewportRegister.h
+++ b/motorApp/NewportSrc/NewportRegister.h
@@ -2,9 +2,6 @@
 FILENAME...	NewportRegister.h
 USAGE... This file contains function prototypes for Newport IOC shell commands.
 
-Version:	$Revision: 1.11 $
-Modified By:	$Author: rivers $
-Last Modified:	$Date: 2006-06-15 19:04:58 $
 */
 
 /*

--- a/motorApp/NewportSrc/SMC100Register.cc
+++ b/motorApp/NewportSrc/SMC100Register.cc
@@ -2,9 +2,6 @@
 FILENAME...	SMC100Register.cc
 USAGE...	Register SMC100 motor device driver shell commands.
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:06:58 $
 */
 
 /*****************************************************************

--- a/motorApp/NewportSrc/SMC100Register.h
+++ b/motorApp/NewportSrc/SMC100Register.h
@@ -2,9 +2,6 @@
 FILENAME...	SMC100Register.h
 USAGE... This file contains function prototypes for SMC100 IOC shell commands.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-07-16 19:06:58 $
 */
 
 /*

--- a/motorApp/NewportSrc/XPSAxis.cpp
+++ b/motorApp/NewportSrc/XPSAxis.cpp
@@ -2,10 +2,6 @@
 FILENAME...     XPSMotorDriver.cpp
 USAGE...        Newport XPS EPICS asyn motor device driver
 
-Version:        $Revision: 19717 $
-Modified By:    $Author: sluiter $
-Last Modified:  $Date: 2009-12-09 10:21:24 -0600 (Wed, 09 Dec 2009) $
-HeadURL:        $URL: https://subversion.xor.aps.anl.gov/synApps/trunk/support/motor/vstub/motorApp/NewportSrc/XPSMotorDriver.cpp $
 */
 
 /*

--- a/motorApp/NewportSrc/XPSController.cpp
+++ b/motorApp/NewportSrc/XPSController.cpp
@@ -2,10 +2,6 @@
 FILENAME...     XPSMotorDriver.cpp
 USAGE...        Newport XPS EPICS asyn motor device driver
 
-Version:        $Revision: 19717 $
-Modified By:    $Author: sluiter $
-Last Modified:  $Date: 2009-12-09 10:21:24 -0600 (Wed, 09 Dec 2009) $
-HeadURL:        $URL: https://subversion.xor.aps.anl.gov/synApps/trunk/support/motor/vstub/motorApp/NewportSrc/XPSMotorDriver.cpp $
 */
  
 /*

--- a/motorApp/NewportSrc/devESP300.cc
+++ b/motorApp/NewportSrc/devESP300.cc
@@ -2,10 +2,6 @@
 FILENAME...	devESP300.cc
 USAGE...	Motor record device level support for Newport ESP300.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/NewportSrc/devMM3000.cc
+++ b/motorApp/NewportSrc/devMM3000.cc
@@ -2,9 +2,6 @@
 FILENAME...	devMM3000.cc
 USAGE...	Motor record device level support for Newport MM3000.
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:17:14 $
 */
 
 /*

--- a/motorApp/NewportSrc/devMM4000.cc
+++ b/motorApp/NewportSrc/devMM4000.cc
@@ -2,10 +2,6 @@
 FILENAME...     devMM4000.cc
 USAGE...        Motor record device level support for Newport MM4000.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/NewportSrc/devPM500.cc
+++ b/motorApp/NewportSrc/devPM500.cc
@@ -3,9 +3,6 @@ FILENAME...	devPM500.cc
 USAGE...	Motor record device level support for the Newport PM500 motor
 		controller.
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2009-08-25 18:24:24 $
 */
 
 /*

--- a/motorApp/NewportSrc/drvESP300.cc
+++ b/motorApp/NewportSrc/drvESP300.cc
@@ -2,10 +2,6 @@
 FILENAME... drvESP300.cc
 USAGE...    Motor record driver level support for Newport ESP300/100.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/NewportSrc/drvMM3000.cc
+++ b/motorApp/NewportSrc/drvMM3000.cc
@@ -2,10 +2,6 @@
 FILENAME... drvMM3000.cc
 USAGE...    Motor record driver level support for Newport MM3000.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/NewportSrc/drvMM4000.cc
+++ b/motorApp/NewportSrc/drvMM4000.cc
@@ -2,10 +2,6 @@
 FILENAME... drvMM4000.cc
 USAGE...    Motor record driver level support for Newport MM4000.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/NewportSrc/drvMM4000Asyn.c
+++ b/motorApp/NewportSrc/drvMM4000Asyn.c
@@ -2,10 +2,6 @@
 FILENAME... drvMM4000Asyn.cc
 USAGE...    Motor record asyn driver level support for Newport MM4000.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/NewportSrc/drvMMCom.h
+++ b/motorApp/NewportSrc/drvMMCom.h
@@ -3,9 +3,6 @@ FILENAME...	drvMMCom.h
 USAGE... This file contains Newport Motion Master (MM) driver "include"
 	    information that is specific to Motion Master models 3000/4000.
 
-Version:	$Revision: 1.10 $
-Modified By:	$Author: rivers $
-Last Modified:	$Date: 2004-08-17 21:28:22 $
 */
 
 /*

--- a/motorApp/NewportSrc/drvPM500.cc
+++ b/motorApp/NewportSrc/drvPM500.cc
@@ -2,10 +2,6 @@
 FILENAME... drvPM500.cc
 USAGE...    Motor record driver level support for Newport PM500.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /* Device Driver Support routines for PM500 motor controller */

--- a/motorApp/NewportSrc/drvXPSAsyn.c
+++ b/motorApp/NewportSrc/drvXPSAsyn.c
@@ -2,10 +2,6 @@
 FILENAME...     drvXPSasyn.c
 USAGE...        Newport XPS EPICS asyn motor device driver
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsBaseAxis.cpp
+++ b/motorApp/OmsAsynSrc/omsBaseAxis.cpp
@@ -2,10 +2,6 @@
 FILENAME...     omsBaseAxis.cpp
 USAGE...        Pro-Dex OMS asyn motor base axes support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 

--- a/motorApp/OmsAsynSrc/omsBaseAxis.h
+++ b/motorApp/OmsAsynSrc/omsBaseAxis.h
@@ -2,10 +2,6 @@
 FILENAME...     omsBaseAxis.h
 USAGE...        Pro-Dex OMS asyn motor base axes support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsBaseController.cpp
+++ b/motorApp/OmsAsynSrc/omsBaseController.cpp
@@ -2,10 +2,6 @@
 FILENAME...     omsBaseController.cpp
 USAGE...        Pro-Dex OMS asyn motor base controller support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsBaseController.h
+++ b/motorApp/OmsAsynSrc/omsBaseController.h
@@ -2,10 +2,6 @@
 FILENAME...     omsBaseController.h
 USAGE...        Pro-Dex OMS asyn motor base controller support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsMAXnet.cpp
+++ b/motorApp/OmsAsynSrc/omsMAXnet.cpp
@@ -2,10 +2,6 @@
 FILENAME...     omsMAXnet.cpp
 USAGE...        Pro-Dex OMS MAXnet asyn motor controller support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsMAXnet.h
+++ b/motorApp/OmsAsynSrc/omsMAXnet.h
@@ -2,10 +2,6 @@
 FILENAME...     omsMAXnet.h
 USAGE...        Pro-Dex OMS MAXnet asyn motor controller support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsMAXv.cpp
+++ b/motorApp/OmsAsynSrc/omsMAXv.cpp
@@ -2,10 +2,6 @@
 FILENAME...     omsMAXv.cpp
 USAGE...        Pro-Dex OMS MAXv asyn motor controller support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsMAXv.h
+++ b/motorApp/OmsAsynSrc/omsMAXv.h
@@ -2,10 +2,6 @@
 FILENAME...     omsMAXv.h
 USAGE...        Pro-Dex OMS MAXv asyn motor controller support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsMAXvEncFunc.cpp
+++ b/motorApp/OmsAsynSrc/omsMAXvEncFunc.cpp
@@ -2,10 +2,6 @@
 FILENAME...     omsMAXvEncFunc.cpp
 USAGE...        Pro-Dex OMS MAXv encoder asyn motor support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsAsynSrc/omsMAXvEncFunc.h
+++ b/motorApp/OmsAsynSrc/omsMAXvEncFunc.h
@@ -2,10 +2,6 @@
 FILENAME...     omsMAXvEncFunc.h
 USAGE...        Pro-Dex OMS MAXv encoder asyn motor support
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/devMAXv.cc
+++ b/motorApp/OmsSrc/devMAXv.cc
@@ -2,10 +2,6 @@
 FILENAME...	devMAXV.cc
 USAGE... Device level support for OMS MAXv model.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/devOms.cc
+++ b/motorApp/OmsSrc/devOms.cc
@@ -3,10 +3,6 @@ FILENAME...	devOms.cc
 USAGE... Device level support for OMS VME8 and VME44 models.
 
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/devOms58.cc
+++ b/motorApp/OmsSrc/devOms58.cc
@@ -2,10 +2,6 @@
 FILENAME...	devOms58.c
 USAGE...	Motor record device level support for OMS VME58.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/devOmsCom.cc
+++ b/motorApp/OmsSrc/devOmsCom.cc
@@ -2,10 +2,6 @@
 FILENAME...     devOmsCom.cc
 USAGE...        Data and functions common to all OMS device level support.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/devOmsCom.h
+++ b/motorApp/OmsSrc/devOmsCom.h
@@ -4,10 +4,6 @@ FILENAME..	devOmsCom.h
 USAGE... 	This file contains OMS device information that is
 		common to all OMS device support modules.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/devOmsPC68.cc
+++ b/motorApp/OmsSrc/devOmsPC68.cc
@@ -2,10 +2,6 @@
 FILENAME...     devOmsPC68.c
 USAGE...        Motor record device level support for OMS VME58.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/drvMAXv.cc
+++ b/motorApp/OmsSrc/drvMAXv.cc
@@ -2,10 +2,6 @@
 FILENAME...     drvMAXv.cc
 USAGE...        Motor record driver level support for OMS model MAXv.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/drvMAXv.h
+++ b/motorApp/OmsSrc/drvMAXv.h
@@ -3,10 +3,6 @@ FILENAME...	drvMAXv.h
 USAGE...	OMS driver level "include" information that is specific to OMS
 		model MAXv.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/drvOms.cc
+++ b/motorApp/OmsSrc/drvOms.cc
@@ -2,10 +2,6 @@
 FILENAME...     drvOms.cc
 USAGE...        Driver level support for OMS models VME8, VME44, VS4 and VX2.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/drvOms.h
+++ b/motorApp/OmsSrc/drvOms.h
@@ -3,9 +3,6 @@ FILENAME...     drvOms.h
 USAGE... This file contains OMS driver "include" information that is
                 specific to OMS models VME8 and VME44.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
 */
 
 /*

--- a/motorApp/OmsSrc/drvOms58.cc
+++ b/motorApp/OmsSrc/drvOms58.cc
@@ -2,10 +2,6 @@
 FILENAME...	drvOms58.cc
 USAGE...	Motor record driver level support for OMS model VME58.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/drvOms58.h
+++ b/motorApp/OmsSrc/drvOms58.h
@@ -3,10 +3,6 @@ FILENAME...     drvOms58.h
 USAGE...        OMS driver level "include" information that is specific to OMS
                 model VME58.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OmsSrc/drvOmsCom.h
+++ b/motorApp/OmsSrc/drvOmsCom.h
@@ -3,9 +3,6 @@ FILENAME...	drvOmsCom.h
 USAGE... 	This file contains OMS driver "include" information
 		that is common to all OMS models.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
 */
 
 /*

--- a/motorApp/OmsSrc/drvOmsPC68.cc
+++ b/motorApp/OmsSrc/drvOmsPC68.cc
@@ -2,9 +2,6 @@
 FILENAME...     drvOmsPC68.cc
 USAGE...        Motor record driver level support for OMS PC68 serial device.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
 */
 
 /*

--- a/motorApp/OmsSrc/drvOmsPC68Com.h
+++ b/motorApp/OmsSrc/drvOmsPC68Com.h
@@ -2,9 +2,6 @@
 FILENAME...     drvOmsPC68Com.h
 USAGE... This file contains information common to all OMS PC68/78 controllers.
 
-Version:	$Revision$
-Modified By:	$Author$
-Last Modified:	$Date$
 */
 
 /*

--- a/motorApp/OrielSrc/OrielRegister.cc
+++ b/motorApp/OrielSrc/OrielRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	OrielRegister.cc
 USAGE...	Register Oriel Encoder/Motor Mike motor device driver shell commands.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-09-07 21:19:43 $
 */
 
 /*****************************************************************

--- a/motorApp/OrielSrc/devEMC18011.cc
+++ b/motorApp/OrielSrc/devEMC18011.cc
@@ -2,9 +2,6 @@
 FILENAME...	devEMC18011.cc
 USAGE...	Motor record device level support for Parker Compumotor drivers
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:19:25 $
 */
 
 /*

--- a/motorApp/OrielSrc/drvEMC18011.cc
+++ b/motorApp/OrielSrc/drvEMC18011.cc
@@ -3,10 +3,6 @@ FILENAME...	drvEMC18011.cc
 USAGE...	Motor record driver level support for Spectra-Physics
                 Encoder Mike Controller (Model: 18011)
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/OrielSrc/drvEMC18011.h
+++ b/motorApp/OrielSrc/drvEMC18011.h
@@ -3,9 +3,6 @@ FILENAME...	drvEMC18011.h
 USAGE...    This file contains Parker Compumotor driver "include"
 	    information that is specific to the 6K series serial controller
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-11-02 21:05:56 $
 */
 
 /*

--- a/motorApp/PC6KSrc/ParkerRegister.cc
+++ b/motorApp/PC6KSrc/ParkerRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	ParkerRegister.cc
 USAGE...	Register Parker/Compumotor motor device driver shell commands.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-08-31 15:42:31 $
 */
 
 /*****************************************************************

--- a/motorApp/PC6KSrc/devPC6K.cc
+++ b/motorApp/PC6KSrc/devPC6K.cc
@@ -2,9 +2,6 @@
 FILENAME...	devPC6K.cc
 USAGE...	Motor record device level support for Parker Compumotor drivers
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:19:43 $
 */
 
 /*

--- a/motorApp/PC6KSrc/drvPC6K.cc
+++ b/motorApp/PC6KSrc/drvPC6K.cc
@@ -3,10 +3,6 @@ FILENAME...	drvPC6K.cc
 USAGE...	Motor record driver level support for Parker Computmotor
                 6K Series motor controllers
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/PC6KSrc/drvPC6K.h
+++ b/motorApp/PC6KSrc/drvPC6K.h
@@ -3,9 +3,6 @@ FILENAME...	drvPC6K.h
 USAGE...    This file contains Parker Compumotor driver "include"
 	    information that is specific to the 6K series serial controller
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-08-31 15:42:31 $
 */
 
 /*

--- a/motorApp/PIGCS2Src/PIC702Controller.cpp
+++ b/motorApp/PIGCS2Src/PIC702Controller.cpp
@@ -8,10 +8,6 @@ USAGE...
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 2$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: January 2011

--- a/motorApp/PIGCS2Src/PIC702Controller.h
+++ b/motorApp/PIGCS2Src/PIC702Controller.h
@@ -7,10 +7,6 @@ FILENAME...     PIC702Controller.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 2$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau
 */

--- a/motorApp/PIGCS2Src/PIE517Controller.cpp
+++ b/motorApp/PIGCS2Src/PIE517Controller.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIGCSPiezoController
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 3$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIE517Controller.h
+++ b/motorApp/PIGCS2Src/PIE517Controller.h
@@ -7,10 +7,6 @@ FILENAME...     PIGCScontroller.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 3$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIE755Controller.cpp
+++ b/motorApp/PIGCS2Src/PIE755Controller.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIE755Controller.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 23.09.2013 14:19:03$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 */

--- a/motorApp/PIGCS2Src/PIE755Controller.h
+++ b/motorApp/PIGCS2Src/PIE755Controller.h
@@ -7,10 +7,6 @@ FILENAME...     PIE755Controller.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 2$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 */

--- a/motorApp/PIGCS2Src/PIGCS2_HexapodController.cpp
+++ b/motorApp/PIGCS2Src/PIGCS2_HexapodController.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIHexapodController.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 05.11.2013 17:38:06$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau
 */

--- a/motorApp/PIGCS2Src/PIGCS2_HexapodController.h
+++ b/motorApp/PIGCS2Src/PIGCS2_HexapodController.h
@@ -7,10 +7,6 @@ FILENAME...     PIHexapodController.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 05.11.2013 17:38:06$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 */

--- a/motorApp/PIGCS2Src/PIGCSController.cpp
+++ b/motorApp/PIGCS2Src/PIGCSController.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIGCSController.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 6$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 05.11.2013 17:38:32$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIGCSController.h
+++ b/motorApp/PIGCS2Src/PIGCSController.h
@@ -7,10 +7,6 @@ FILENAME...     PIGCScontroller.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 5$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 05.11.2013 17:38:32$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIGCSMotorController.cpp
+++ b/motorApp/PIGCS2Src/PIGCSMotorController.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIGCSMotorController.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 2$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIGCSMotorController.h
+++ b/motorApp/PIGCS2Src/PIGCSMotorController.h
@@ -7,10 +7,6 @@ FILENAME...     PIGCSMotorController.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 2$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIGCSPiezoController.cpp
+++ b/motorApp/PIGCS2Src/PIGCSPiezoController.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIGCSPiezoController.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 3$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIGCSPiezoController.h
+++ b/motorApp/PIGCS2Src/PIGCSPiezoController.h
@@ -7,10 +7,6 @@ FILENAME...     PIGCScontroller.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 3$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIHexapodController.cpp
+++ b/motorApp/PIGCS2Src/PIHexapodController.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIHexapodController.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 5$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 05.11.2013 17:38:32$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau
 */

--- a/motorApp/PIGCS2Src/PIHexapodController.h
+++ b/motorApp/PIGCS2Src/PIHexapodController.h
@@ -7,10 +7,6 @@ FILENAME...     PIHexapodController.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 3$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 05.11.2013 17:38:32$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 */

--- a/motorApp/PIGCS2Src/PIInterface.cpp
+++ b/motorApp/PIGCS2Src/PIInterface.cpp
@@ -7,10 +7,6 @@ FILENAME...     PIInterface.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:42:52$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIInterface.h
+++ b/motorApp/PIGCS2Src/PIInterface.h
@@ -7,10 +7,6 @@ FILENAME...     PIInterface.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:42:52$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: 15.12.2010

--- a/motorApp/PIGCS2Src/PIasynAxis.cpp
+++ b/motorApp/PIGCS2Src/PIasynAxis.cpp
@@ -8,10 +8,6 @@ USAGE...
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 4$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 

--- a/motorApp/PIGCS2Src/PIasynAxis.h
+++ b/motorApp/PIGCS2Src/PIasynAxis.h
@@ -8,10 +8,6 @@ USAGE...        PI GCS Motor Support.
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
  
-Version:        $Revision: 2$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 09.10.2013 16:34:01$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 Created: January 2011

--- a/motorApp/PIGCS2Src/PIasynController.cpp
+++ b/motorApp/PIGCS2Src/PIasynController.cpp
@@ -8,10 +8,6 @@ USAGE...        PI GCS2 Motor Support.
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
  
-Version:        $Revision: 4$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 25.10.2013 10:43:08$
-HeadURL:        $URL$
  
 Original Author: Steffen Rau
 Created: January 2011

--- a/motorApp/PIGCS2Src/PIasynController.h
+++ b/motorApp/PIGCS2Src/PIasynController.h
@@ -7,10 +7,6 @@ FILENAME...     PIasynController.cpp
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
  
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 23.09.2013 14:19:03$
-HeadURL:        $URL$
 
 Based on drvMotorSim.c
 

--- a/motorApp/PIGCS2Src/picontrollererrors.h
+++ b/motorApp/PIGCS2Src/picontrollererrors.h
@@ -7,10 +7,6 @@ FILENAME...     picontrollererrors.h
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
   
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 23.09.2013 14:19:03$
-HeadURL:        $URL$
  
 Original Author: Steffen Rau, January 2011
 */

--- a/motorApp/PIGCS2Src/translateerror.c
+++ b/motorApp/PIGCS2Src/translateerror.c
@@ -7,10 +7,6 @@ FILENAME...     translateerror.c
 * found in the file LICENSE that is included with this distribution.
 *************************************************************************
 
-Version:        $Revision: 1$
-Modified By:    $Author: Steffen Rau$
-Last Modified:  $Date: 23.09.2013 14:19:03$
-HeadURL:        $URL$
 
 Original Author: Steffen Rau 
 */

--- a/motorApp/PhytronSrc/phytronAxisMotor.cpp
+++ b/motorApp/PhytronSrc/phytronAxisMotor.cpp
@@ -5,10 +5,6 @@ USAGE...    Motor driver support for Phytron Axis controller.
 Tom Slejko & Bor Marolt
 Cosylab d.d. 2014
  
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 #include <stdio.h>

--- a/motorApp/PhytronSrc/phytronAxisMotor.h
+++ b/motorApp/PhytronSrc/phytronAxisMotor.h
@@ -5,10 +5,6 @@ USAGE...    Motor record  support for Phytron Axis controller.
 Tom Slejko & Bor Marolt
 Cosylab d.d. 2014
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 #include "asynMotorController.h"

--- a/motorApp/PiJenaSrc/PIJEDS_Register.cc
+++ b/motorApp/PiJenaSrc/PIJEDS_Register.cc
@@ -2,9 +2,6 @@
 FILENAME...	PIJEDS_Register.cc
 USAGE...	Register piezosystem jena motor device driver shell commands.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2007-06-14 15:56:59 $
 */
 
 /*****************************************************************

--- a/motorApp/PiJenaSrc/devPIJEDS.cc
+++ b/motorApp/PiJenaSrc/devPIJEDS.cc
@@ -3,9 +3,6 @@ FILENAME...	devPIJEDS.cc
 USAGE...	Motor record device level support for Physik Instrumente (PI)
 		GmbH & Co. E-516 motor controller.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:20:03 $
 */
 
 /*

--- a/motorApp/PiJenaSrc/drvPIJEDS.cc
+++ b/motorApp/PiJenaSrc/drvPIJEDS.cc
@@ -3,10 +3,6 @@ FILENAME...	drvPIJEDS.cc
 USAGE...	Motor record driver level support for piezosystem jena
 	        GmbH & Co. E-516 motor controller.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$*/
 
 /*
  *      Original Author: Joe Sullivan

--- a/motorApp/PiSrc/PIC662Register.cc
+++ b/motorApp/PiSrc/PIC662Register.cc
@@ -2,9 +2,6 @@
 FILENAME...	PiRegister.cc
 USAGE...	Register IMS motor device driver shell commands.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-04-14 20:34:42 $
 */
 
 /*****************************************************************

--- a/motorApp/PiSrc/PIC848Register.cc
+++ b/motorApp/PiSrc/PIC848Register.cc
@@ -2,9 +2,6 @@
 FILENAME...	PIC848Register.cc
 USAGE...	Register PI motor device driver shell commands.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2005-10-04 19:45:52 $
 */
 
 /*****************************************************************

--- a/motorApp/PiSrc/PIE516Register.cc
+++ b/motorApp/PiSrc/PIE516Register.cc
@@ -2,9 +2,6 @@
 FILENAME...	PIE516Register.cc
 USAGE...	Register PI motor device driver shell commands.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2007-03-30 20:01:05 $
 */
 
 /*****************************************************************

--- a/motorApp/PiSrc/PIE710Register.cc
+++ b/motorApp/PiSrc/PIE710Register.cc
@@ -2,9 +2,6 @@
 FILENAME...	PIE710Register.cc
 USAGE...	Register PI motor device driver shell commands.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-10-06 18:18:21 $
 */
 
 /*****************************************************************

--- a/motorApp/PiSrc/PiRegister.cc
+++ b/motorApp/PiSrc/PiRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	PiRegister.cc
 USAGE...	Register IMS motor device driver shell commands.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2004-12-20 21:30:38 $
 */
 
 /*****************************************************************

--- a/motorApp/PiSrc/devPIC662.cc
+++ b/motorApp/PiSrc/devPIC662.cc
@@ -3,9 +3,6 @@ FILENAME...	devPIC662.cc
 USAGE...	Motor record device level support for Physik Instrumente (PI)
 		GmbH & Co. C-844 motor controller.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:21:36 $
 */
 
 /*

--- a/motorApp/PiSrc/devPIC844.cc
+++ b/motorApp/PiSrc/devPIC844.cc
@@ -3,9 +3,6 @@ FILENAME...	devPIC844.cc
 USAGE...	Motor record device level support for Physik Instrumente (PI)
 		GmbH & Co. C-844 motor controller.
 
-Version:	$Revision: 1.6 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:21:36 $
 */
 
 /*

--- a/motorApp/PiSrc/devPIC848.cc
+++ b/motorApp/PiSrc/devPIC848.cc
@@ -3,9 +3,6 @@ FILENAME...	devPIC848.cc
 USAGE...	Motor record device level support for Physik Instrumente (PI)
 		GmbH & Co. C-848 motor controller.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:21:37 $
 */
 
 /*

--- a/motorApp/PiSrc/devPIE516.cc
+++ b/motorApp/PiSrc/devPIE516.cc
@@ -3,9 +3,6 @@ FILENAME...	devPIE516.cc
 USAGE...	Motor record device level support for Physik Instrumente (PI)
 		GmbH & Co. E-516 motor controller.
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:21:37 $
 */
 
 /*

--- a/motorApp/PiSrc/devPIE710.cc
+++ b/motorApp/PiSrc/devPIE710.cc
@@ -3,9 +3,6 @@ FILENAME...	devPIE710.cc
 USAGE...	Motor record device level support for Physik Instrumente (PI)
 		GmbH & Co. E-710 motor controller.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:21:36 $
 */
 
 /*

--- a/motorApp/PiSrc/drvPI.h
+++ b/motorApp/PiSrc/drvPI.h
@@ -3,9 +3,6 @@ FILENAME...	drvPI.h
 USAGE... This file contains driver "include" information that is specific to
 Physik Instrumente (PI) GmbH & Co. motor controller driver support.
 
-Version:	$Revision: 1.3 $
-Modified By:	$Author: rivers $
-Last Modified:	$Date: 2004-08-17 21:29:52 $
 */
 
 /*

--- a/motorApp/PiSrc/drvPIC662.cc
+++ b/motorApp/PiSrc/drvPIC662.cc
@@ -3,9 +3,6 @@ FILENAME...	drvPIC662.cc
 USAGE...	Motor record driver level support for Physik Instrumente (PI)
 		GmbH & Co. C-844 motor controller.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-04-14 20:34:42 $
 */
 
 /*

--- a/motorApp/PiSrc/drvPIC662.h
+++ b/motorApp/PiSrc/drvPIC662.h
@@ -3,9 +3,6 @@ FILENAME...	drvPIC662.h
 USAGE... This file contains driver "include" information that is specific to
 Physik Instrumente (PI) GmbH & Co. motor controller driver support.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-04-14 20:34:42 $
 */
 
 /*

--- a/motorApp/PiSrc/drvPIC844.cc
+++ b/motorApp/PiSrc/drvPIC844.cc
@@ -3,9 +3,6 @@ FILENAME...	drvPIC844.cc
 USAGE...	Motor record driver level support for Physik Instrumente (PI)
 		GmbH & Co. C-844 motor controller.
 
-Version:	$Revision: 1.15 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2006-01-31 22:10:04 $
 */
 
 /*

--- a/motorApp/PiSrc/drvPIC848.cc
+++ b/motorApp/PiSrc/drvPIC848.cc
@@ -3,10 +3,6 @@ FILENAME...	drvPIC848.cc
 USAGE...	Motor record driver level support for Physik Instrumente (PI)
 	GmbH & Co. C-848 motor controller.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/PiSrc/drvPIE516.cc
+++ b/motorApp/PiSrc/drvPIE516.cc
@@ -3,9 +3,6 @@ FILENAME...	drvPIE516.cc
 USAGE...	Motor record driver level support for Physik Instrumente (PI)
 	        GmbH & Co. E-516 motor controller.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2007-03-30 20:01:05 $
 */
 
 /*

--- a/motorApp/PiSrc/drvPIE710.cc
+++ b/motorApp/PiSrc/drvPIE710.cc
@@ -3,9 +3,6 @@ FILENAME...	drvPIE710.cc
 USAGE...	Motor record driver level support for Physik Instrumente (PI)
 	        GmbH & Co. E-710 motor controller.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-10-06 18:18:22 $
 */
 
 /*

--- a/motorApp/SmartMotorSrc/devSmartMotor.cc
+++ b/motorApp/SmartMotorSrc/devSmartMotor.cc
@@ -2,9 +2,6 @@
 FILENAME... devSmartMotor.cc
 USAGE...    Motor record driver level support for Animatics Corporation SmartMotors.
 
-Version:        $Revision: 1.2 $
-Modified By:    $Author: sluiter $
-Last Modified:  $Date: 2008-03-14 20:21:56 $
 */
 
 /*

--- a/motorApp/SmartMotorSrc/drvSmartMotor.cc
+++ b/motorApp/SmartMotorSrc/drvSmartMotor.cc
@@ -2,9 +2,6 @@
 FILENAME... drvSmartMotor.cc
 USAGE...    Motor record driver level support for Animatics Corporation SmartMotors.
 
-Version:        $Revision: 1.3 $
-Modified By:    $Author: rivers $
-Last Modified:  $Date: 2007-09-13 16:36:38 $
 */
 
 /*

--- a/motorApp/SoftMotorSrc/devSoft.cc
+++ b/motorApp/SoftMotorSrc/devSoft.cc
@@ -2,10 +2,6 @@
 FILENAME...     devSoft.cc
 USAGE...        Motor record device level support for Soft channel.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/SoftMotorSrc/devSoft.h
+++ b/motorApp/SoftMotorSrc/devSoft.h
@@ -4,10 +4,6 @@ FILENAME..	devSoft.h
 USAGE... 	This file contains information that is common to
 		all Soft channel device support modules.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/SoftMotorSrc/devSoftAux.cc
+++ b/motorApp/SoftMotorSrc/devSoftAux.cc
@@ -2,10 +2,6 @@
 FILENAME...     devSoftAux.cc
 USAGE...        Motor record device level support for Soft channel.
 
-Version:        $Revision$
-Modified By:    $Author$
-Last Modified:  $Date$
-HeadURL:        $URL$
 */
 
 /*

--- a/motorApp/ThorLabsSrc/ThorLabsRegister.cc
+++ b/motorApp/ThorLabsSrc/ThorLabsRegister.cc
@@ -2,9 +2,6 @@
 FILENAME...	ThorLabslRegister.cc
 USAGE...	Register ThorLabs  motor device driver shell commands.
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-09-27 20:32:37 $
 */
 
 /*****************************************************************

--- a/motorApp/ThorLabsSrc/devMDT695.cc
+++ b/motorApp/ThorLabsSrc/devMDT695.cc
@@ -3,9 +3,6 @@ FILENAME...	devMDT695.cc
 USAGE...	Motor record device level support for ThorLabs Piezo Control
                 Module (MDT695)
 
-Version:	$Revision: 1.2 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2008-03-14 20:23:45 $
 */
 
 /*

--- a/motorApp/ThorLabsSrc/drvMDT695.cc
+++ b/motorApp/ThorLabsSrc/drvMDT695.cc
@@ -4,9 +4,6 @@ USAGE...	Motor record driver level support for ThorLabs
                 Piezo Control Module (Model: MDT695)
 		Compatable with MDT694, MDT693
 
-Version:	$Revision: 1.4 $
-Modified By:	$Author: sluiter $
-Last Modified:	$Date: 2009-09-08 18:36:20 $
 
 */
 

--- a/motorApp/ThorLabsSrc/drvMDT695.h
+++ b/motorApp/ThorLabsSrc/drvMDT695.h
@@ -3,9 +3,6 @@ FILENAME...	drvMDT695.h
 USAGE...    This file contains ThorLabs Piezo Control Module (MDT695)
 	    motorRecord driver information . 
 
-Version:	$Revision: 1.1 $
-Modified By:	$Author: sullivan $
-Last Modified:	$Date: 2006-09-27 20:32:37 $
 */
 
 /*

--- a/motorExApp/NoAsyn/Makefile
+++ b/motorExApp/NoAsyn/Makefile
@@ -1,10 +1,6 @@
 #FILENAME...     Makefile
 #USAGE...        Makefile for motor application example without Asyn
 
-#Version:        $Revision$
-#Modified By:    $Author$
-#Last Modified:  $Date$
-#HeadURL:        $URL$
 
 # "#!" marks lines that can be uncommented.
 

--- a/motorExApp/WithAsyn/Makefile
+++ b/motorExApp/WithAsyn/Makefile
@@ -1,10 +1,6 @@
 #FILENAME...     Makefile
 #USAGE...        Makefile for motor application example with Asyn
 
-#Version:        $Revision$
-#Modified By:    $Author$
-#Last Modified:  $Date$
-#HeadURL:        $URL$
 
 # "#!" marks lines that can be uncommented.
 


### PR DESCRIPTION
They have no meaning in Git, are not updated and may cause unwanted diffs when
otherwise nothing is changed in a file