### PR TITLE
Jog limit

### DIFF
--- a/documentation/motorRecord.html
+++ b/documentation/motorRecord.html
@@ -301,8 +301,7 @@ below.
     <td>R</td>
     <td>Raw commanded direction</td>
     <td>SHORT</td>
-    <td><br>
-    </td>
+    <td>(1:"Pos", 0:"Neg")<br></td>
   </tr>
   <tr>
     <td><a href="#Servo_fields">CNEN</a></td>
@@ -3124,8 +3123,8 @@ below.
     <td>R</td>
     <td>Raw commanded direction<br>
     </td>
-    <td>SHORT<br>
-    </td>
+    <td>SHORT<br></td>
+    <td>(1:"Pos", 0:"Neg")<br></td>
   </tr>
   <tr valign="top">
     <td>PP</td>

--- a/iocBoot/iocNoAsyn/st.cmd.Vx
+++ b/iocBoot/iocNoAsyn/st.cmd.Vx
@@ -42,7 +42,7 @@ dbLoadRecords("$(MOTOR)/db/motorUtil.db", "P=IOC:")
 #     (2)VME Address Space - A(16,24,32).
 #     (3)Base Address (see README file).
 #     (4)interrupt vector (0=disable or  64 - 255).
-#     (5)interrupt level (1 - 6).
+#     (5)interrupt level (2 - 6).
 #     (6)motor task polling rate (min=1Hz,max=60Hz).
 #!MAXvSetup(1, 16,     0xF000, 200, 5, 10)
 #!MAXvSetup(1, 24,   0xFF0000, 200, 5, 10)

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -180,9 +180,9 @@ USAGE...        Motor Record Support.
  *                  - Reversed order of issuing SET_VEL_BASE and SET_VELOCITY commands. Fixes MAXv
  *                    command errors.
  * .71 02-25-15 rls - Fix for excessive motor record forward link processing.
- * 
  * .72 03-13-15 rls - Changed RDBL to set RRBV rather than DRBV.
- * 
+ * .73 02-15-16 rls - JOGF/R soft limit error check was using the wrong coordinate sytem limits.
+ *                    Changed error checks from dial to user limits.
  */                                                          
 
 #define VERSION 6.10
@@ -1366,8 +1366,8 @@ enter_do_work:
     else
     {
         if (pmr->mip & MIP_JOG)
-            pmr->lvio = (pmr->jogf && (pmr->drbv > pmr->dhlm - pmr->jvel)) ||
-                        (pmr->jogr && (pmr->drbv < pmr->dllm + pmr->jvel));
+            pmr->lvio = (pmr->jogf && (pmr->rbv > pmr->hlm - pmr->jvel)) ||
+                        (pmr->jogr && (pmr->rbv < pmr->llm + pmr->jvel));
         else if (pmr->mip & MIP_HOME)
             pmr->lvio = false;  /* Disable soft-limit error check during home search. */
     }
@@ -1972,8 +1972,8 @@ static RTN_STATUS do_work(motorRecord * pmr, CALLBACK_VALUE proc_ind)
             /* check for limit violation */
             if ((pmr->dhlm == pmr->dllm) && (pmr->dllm == 0.0))
                 ;
-            else if ((pmr->jogf && (pmr->dval > pmr->dhlm - pmr->jvel)) ||
-                     (pmr->jogr && (pmr->dval < pmr->dllm + pmr->jvel)))
+            else if ((pmr->jogf && (pmr->val > pmr->hlm - pmr->jvel)) ||
+                     (pmr->jogr && (pmr->val < pmr->llm + pmr->jvel)))
             {
                 pmr->lvio = 1;
                 MARK(M_LVIO);


### PR DESCRIPTION
Hello Torsten,
Sorry it has taken me 4 months to address this.

The problem you raised (i.e., jog does work with soft limits when DIR is true) is valid but I do not agree with the solution. CDIR is defined in motorRecord.html as the "Raw commanded direction" and JOG[F/R] are defined as a "move in the indicated direction (in user coordinates)". With DIR set to "Negative", CDIR should be the opposite of the Jog direction.

After several days of trying in vain to find a better solution, I noticed that the jog soft travel limit error checks are using the "dial" coordinate system. They should be using the "user" coordinate system.

I put the required changes in this pull request. I have tested and confirmed these changes work with a model #1 MAXv driver and a model #2 Aerotech Ensemble driver. Can you please confirm that these changes fix the problem you raised?

(I went back to the earliest version of this code that I could find and found that this problem has been there since the beginning. The jog function does not get used very often.)