### PR TITLE
When homing, the LS don't mean done

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -3604,7 +3604,10 @@ static void process_motor_info(motorRecord * pmr, bool initcall)
     pmr->rhls = (msta.Bits.RA_PLUS_LS)  &&  pmr->cdir;
     pmr->rlls = (msta.Bits.RA_MINUS_LS) && !pmr->cdir;
 
-    ls_active = (pmr->rhls || pmr->rlls) ? true : false;
+    if ((pmr->mip & MIP_HOMF) || (pmr->mip & MIP_HOMR))
+        ls_active = false;
+    else
+        ls_active = (pmr->rhls || pmr->rlls) ? true : false;
     
     pmr->hls = ((pmr->dir == motorDIR_Pos) == (pmr->mres >= 0)) ? pmr->rhls : pmr->rlls;
     pmr->lls = ((pmr->dir == motorDIR_Pos) == (pmr->mres >= 0)) ? pmr->rlls : pmr->rhls;


### PR DESCRIPTION
Depdending on the homing sequence, the motor may drive against a limit switch,
return and search for the home switch.

When the limit switch is hit, motorRecord assumes "done",
even if the sequence is not completet.

Whenever homing, don't use (pmr->rhls || pmr->rlls) to synthesize "done",
but wait until the controller returns "done".
