### PR TITLE
Corrected setIntegerParam() calls in PIasyn{Axis,Controller}.cpp

### DIFF
--- a/motorApp/PIGCS2Src/PIasynAxis.cpp
+++ b/motorApp/PIGCS2Src/PIasynAxis.cpp
@@ -82,7 +82,7 @@ void PIasynAxis::Init(const char *portName)
 	}
 	m_pGCSController->m_pInterface->m_pCurrentLogSink = logSink;
 
-	setIntegerParam(motorAxisHasClosedLoop, 1);
+	setIntegerParam(pController_->motorStatusGainSupport_, 1);
 
 	m_pGCSController->initAxis(this);
 	double resolution;

--- a/motorApp/PIGCS2Src/PIasynController.cpp
+++ b/motorApp/PIGCS2Src/PIasynController.cpp
@@ -397,7 +397,7 @@ asynStatus PIasynController::configAxis(PIasynAxis *pAxis)
 	}
 	m_pGCSController->m_pInterface->m_pCurrentLogSink = logSink;
     
-    pAxis->setIntegerParam(motorAxisHasClosedLoop, 1);
+    pAxis->setIntegerParam(this->motorStatusGainSupport_, 1);
     pAxis->callParamCallbacks();
 
     m_pGCSController->initAxis(pAxis);


### PR DESCRIPTION
Replaced motorAxisHasClosedLoop with pController_->motorStatusGainSupport_ in calls to setIntegerParam()

Fixes #22 