### PR TITLE
Clear the problem bit in MSTA as part of the home function.

### DIFF
--- a/motorApp/NewportSrc/XPSAxis.cpp
+++ b/motorApp/NewportSrc/XPSAxis.cpp
@@ -356,6 +356,8 @@ asynStatus XPSAxis::home(double min_velocity, double max_velocity, double accele
   }
   moving_ = true;
 
+  setIntegerParam(pC_->motorStatusProblem_, 0);
+
   return asynSuccess;
 }
 


### PR DESCRIPTION
This fixes a problem introduced in the motor record to do with issuing stops when the record has the RA_PROBLEM bit set. This broke the home function for the XPS controller, because we have to re-home from a problem state. The motor record was issuing a stop as soon as the home function completed, causing the home procedure on the XPS to fail.