### PR TITLE
Switch asynMotorAxis status_ and statusChanged_ to be protected

### DIFF
--- a/motorApp/MotorSrc/asynMotorAxis.h
+++ b/motorApp/MotorSrc/asynMotorAxis.h
@@ -72,10 +72,10 @@ class epicsShareClass asynMotorAxis {
   double *profileReadbacks_;         /**< Array of readback positions for profile moves */
   double *profileFollowingErrors_;   /**< Array of following errors for profile moves */   
   int referencingMode_;
+
+  private:
   MotorStatus status_;
   int statusChanged_;
-  
-  private:
   int referencingModeMove_;
   int wasMovingFlag_;
   int disableFlag_;

--- a/motorApp/MotorSrc/asynMotorAxis.h
+++ b/motorApp/MotorSrc/asynMotorAxis.h
@@ -73,9 +73,10 @@ class epicsShareClass asynMotorAxis {
   double *profileFollowingErrors_;   /**< Array of following errors for profile moves */   
   int referencingMode_;
 
-  private:
   MotorStatus status_;
   int statusChanged_;
+
+  private:
   int referencingModeMove_;
   int wasMovingFlag_;
   int disableFlag_;

--- a/motorApp/MotorSrc/asynMotorAxis.h
+++ b/motorApp/MotorSrc/asynMotorAxis.h
@@ -72,10 +72,10 @@ class epicsShareClass asynMotorAxis {
   double *profileReadbacks_;         /**< Array of readback positions for profile moves */
   double *profileFollowingErrors_;   /**< Array of following errors for profile moves */   
   int referencingMode_;
-
-  private:
   MotorStatus status_;
   int statusChanged_;
+  
+  private:
   int referencingModeMove_;
   int wasMovingFlag_;
   int disableFlag_;


### PR DESCRIPTION
The asynMotorController and asynMotorAxis use a hacky workaround to allow developers to not have to write pC_-> in front of all their setXXXXParam calls. This unfortunately causes the asynMotorController to not work correctly if outside code tries to set the motor status or position. Normally, this doesn't matter because the only code changing those parameters is the motor axis. However, I have run into an issue where a motor axis will be calling an outside function that identifies an asyn port and attempts to set parameters. The current setup of the asynMotorController/Axis precludes this ability. 

Ideally, the asynMotorController and Axis would be rewritten to work like a standard asynPortDriver in all instances. But, since the Polling Thread and all Gen3 drivers expect the current behavior and because this is a very obscure issue to run into, a more simple change is in order. If the status_ and statusChanged_ fields were marked protected instead of private, I could simply write my own hacky functions to allow the correct behavior in my subclass and everything would work out fine.