### PR TITLE
Reverted FLNK change. Except for the condition that DMOV == FALSE, FL…

### DIFF
--- a/motorApp/MotorSrc/motorRecord.dbd
+++ b/motorApp/MotorSrc/motorRecord.dbd
@@ -586,11 +586,6 @@ recordtype(motor) {
                 special(SPC_NOMOD)
                 initial("1")
         }
-        field(LDMV,DBF_SHORT) {
-                prompt("Last Done moving value")
-                special(SPC_NOMOD)
-                initial("1")
-        }
         field(MOVN,DBF_SHORT) {
                 prompt("Motor is moving")
                 special(SPC_NOMOD)


### PR DESCRIPTION
…NK processing was standard.
If processing is needed on a DMOV false to true transition, then a new field should be added to accomplish this.