### PR TITLE
Remove errors when printing size_t with %d; Remove unused variables

### DIFF
--- a/motorApp/AttocubeSrc/drvANC150Asyn.cc
+++ b/motorApp/AttocubeSrc/drvANC150Asyn.cc
@@ -364,7 +364,6 @@ static int motorAxisSetDouble(AXIS_HDL pAxis, motorAxisParam_t function, double 
 static int motorAxisSetInteger(AXIS_HDL pAxis, motorAxisParam_t function, int value)
 {
     int ret_status = MOTOR_AXIS_ERROR;
-    int status;
     char buff[20];
 
     if (pAxis == NULL)
@@ -387,7 +386,7 @@ static int motorAxisSetInteger(AXIS_HDL pAxis, motorAxisParam_t function, int va
         break;
     }
     if (ret_status != MOTOR_AXIS_ERROR)
-        status = motorParam->setInteger(pAxis->params, function, value);
+        ret_status = motorParam->setInteger(pAxis->params, function, value);
     return(ret_status);
 }
 
@@ -811,8 +810,8 @@ static int sendOnly(ANC150Controller * pController, char *outputBuff)
     if (status != asynSuccess)
     {
         asynPrint(pController->pasynUser, ASYN_TRACE_ERROR,
-                  "drvANC150Asyn:sendOnly: error sending command %d, sent=%d, status=%d\n",
-                  outputBuff, nActual, status);
+                  "drvANC150Asyn:sendOnly: error sending command %s, sent=%ld, status=%d\n",
+                  outputBuff, (long)nActual, status);
     }
 
     return(status);
@@ -899,7 +898,6 @@ static asynStatus getFreq(ANC150Controller *pController, int axis)
         
 static bool stpMode(ANC150Controller *pController, int axis)
 {
-    asynStatus status;
     char inputBuff[BUFFER_SIZE];
     char outputBuff[BUFFER_SIZE];
     size_t nRead;
@@ -907,7 +905,7 @@ static bool stpMode(ANC150Controller *pController, int axis)
     bool rtnstatus;
 
     sprintf(outputBuff, "getm %d", axis + 1);
-    status = sendAndReceive(pController, outputBuff, inputBuff, sizeof(inputBuff));
+    (void)sendAndReceive(pController, outputBuff, inputBuff, sizeof(inputBuff));
 
     if (strncmp(inputBuff, "mode = stp", 11) == 0)
         rtnstatus = true;
@@ -916,8 +914,8 @@ static bool stpMode(ANC150Controller *pController, int axis)
     else if (strncmp(inputBuff, "Axis not in computer control mode", 34) == 0)
     {
         /* Eat the ERROR msg. */
-        status = pasynOctetSyncIO->read(pController->pasynUser, inputBuff,
-                                        sizeof(inputBuff), TIMEOUT, &nRead, &eomReason);
+        (void)pasynOctetSyncIO->read(pController->pasynUser, inputBuff,
+                                     sizeof(inputBuff), TIMEOUT, &nRead, &eomReason);
         rtnstatus = false;
     }
     else

--- a/motorApp/MicronixSrc/MMC200Driver.cpp
+++ b/motorApp/MicronixSrc/MMC200Driver.cpp
@@ -39,7 +39,6 @@ MMC200Controller::MMC200Controller(const char *portName, const char *MMC200PortN
 {
   int axis;
   asynStatus status;
-  MMC200Axis *pAxis;
   static const char *functionName = "MMC200Controller::MMC200Controller";
 
   /* Set flag to ignore limits */
@@ -56,7 +55,7 @@ MMC200Controller::MMC200Controller(const char *portName, const char *MMC200PortN
       functionName);
   }
   for (axis=0; axis<numAxes; axis++) {
-    pAxis = new MMC200Axis(this, axis);
+    new MMC200Axis(this, axis);
   }
 
   startPoller(movingPollPeriod, idlePollPeriod, 2);
@@ -74,9 +73,7 @@ MMC200Controller::MMC200Controller(const char *portName, const char *MMC200PortN
 extern "C" int MMC200CreateController(const char *portName, const char *MMC200PortName, int numAxes, 
                                    int movingPollPeriod, int idlePollPeriod, int ignoreLimits)
 {
-  MMC200Controller *pMMC200Controller
-    = new MMC200Controller(portName, MMC200PortName, numAxes, movingPollPeriod/1000., idlePollPeriod/1000., ignoreLimits);
-  pMMC200Controller = NULL;
+  new MMC200Controller(portName, MMC200PortName, numAxes, movingPollPeriod/1000., idlePollPeriod/1000., ignoreLimits);
   return(asynSuccess);
 }
 

--- a/motorApp/OmsAsynSrc/omsBaseAxis.cpp
+++ b/motorApp/OmsAsynSrc/omsBaseAxis.cpp
@@ -94,9 +94,7 @@ asynStatus omsBaseAxis::home(double min_velocity, double max_velocity, double ac
     asynStatus status = asynError;
     char buff[60];
     char *direction[2] = {(char*) "HR", (char*) "HM"};
-    epicsInt32 minvelo, velo, acc, fw = 0;
-
-    if (forwards) fw = 1;
+    epicsInt32 minvelo, velo, acc;
 
     velo = (epicsInt32) max_velocity;
     if (velo < 1) velo = 1;

--- a/motorApp/OmsAsynSrc/omsMAXnet.cpp
+++ b/motorApp/OmsAsynSrc/omsMAXnet.cpp
@@ -33,12 +33,11 @@ extern "C" {epicsExportAddress(int, motorMAXnetdebug);}
 
 static void connectCallback(asynUser *pasynUser, asynException exception)
 {
-    asynStatus status;
     int connected = 0;
     omsMAXnet* pController = (omsMAXnet*)pasynUser->userPvt;
 
     if (exception == asynExceptionConnect) {
-        status = pasynManager->isConnected(pasynUser, &connected);
+        (void)pasynManager->isConnected(pasynUser, &connected);
         if (connected){
             if (motorMAXnetdebug & 8) asynPrint(pasynUser, ASYN_TRACE_FLOW,
                 "MAXnet connectCallback:  TCP-Port connected\n");
@@ -164,7 +163,6 @@ omsMAXnet::omsMAXnet(const char* portName, int numAxes, const char* serialPortNa
 epicsEventWaitStatus omsMAXnet::waitInterruptible(double timeout)
 {
     double pollWait, timeToWait = timeout;
-    asynStatus status;
     size_t nRead;
     char inputBuff[1];
     int eomReason = 0;
@@ -185,8 +183,8 @@ epicsEventWaitStatus omsMAXnet::waitInterruptible(double timeout)
          * poll event, if a notification is outstanding. One character will be read. */
         if (enabled) {
             pasynManager->lockPort(pasynUserSerial);
-            status = pasynOctetSerial->read(octetPvtSerial, pasynUserSerial, inputBuff,
-                                                0, &nRead, &eomReason);
+            (void)pasynOctetSerial->read(octetPvtSerial, pasynUserSerial, inputBuff,
+                                         0, &nRead, &eomReason);
             pasynManager->unlockPort(pasynUserSerial);
         }
         if (epicsEventWaitWithTimeout(pollEventId_, pollWait) == epicsEventWaitOK) {
@@ -211,8 +209,8 @@ asynStatus omsMAXnet::sendOnly(const char *outputBuff)
 
     if (status != asynSuccess) {
         asynPrint(pasynUserSyncIOSerial, ASYN_TRACE_ERROR,
-                  "drvMAXnetAsyn:sendOnly: error sending command %s, sent=%d, status=%d\n",
-                  outputBuff, nActual, status);
+                  "drvMAXnetAsyn:sendOnly: error sending command %s, sent=%ld, status=%d\n",
+                  outputBuff, (long)nActual, status);
     }
     Debug(4, "omsMAXnet::sendOnly: wrote: %s \n", outputBuff);
     return(status);
@@ -327,7 +325,6 @@ int omsMAXnet::isNotification (char *buffer) {
  */
 bool omsMAXnet::resetConnection(){
 
-    asynStatus status;
     int autoConnect;
 
     asynInterface *pasynInterface = pasynManager->findInterface(pasynUserSerial,asynCommonType,1);
@@ -337,8 +334,8 @@ bool omsMAXnet::resetConnection(){
     pasynManager->isAutoConnect(pasynUserSerial, &autoConnect);
 
     errlogPrintf("*** disconnect and reconnect serial/IP connection ****\n");
-    status = pasynCommonIntf->disconnect(pasynInterface->drvPvt, pasynUserSerial);
-    if (!autoConnect) status = pasynCommonIntf->connect(pasynInterface->drvPvt, pasynUserSerial);
+    (void)pasynCommonIntf->disconnect(pasynInterface->drvPvt, pasynUserSerial);
+    if (!autoConnect) (void)pasynCommonIntf->connect(pasynInterface->drvPvt, pasynUserSerial);
     epicsThreadSleep(0.1);
     if (portConnected) errlogPrintf("*** reconnect done ****\n");
 

--- a/motorApp/OmsAsynSrc/omsMAXnet.h
+++ b/motorApp/OmsAsynSrc/omsMAXnet.h
@@ -32,7 +32,6 @@ private:
     asynUser* pasynUserSyncIOSerial;
     asynOctet *pasynOctetSerial;
     void* octetPvtSerial;
-    char* serialPortName;
     double timeout;
 };
 

--- a/motorApp/PIGCS2Src/PIGCSController.cpp
+++ b/motorApp/PIGCS2Src/PIGCSController.cpp
@@ -163,7 +163,7 @@ asynStatus PIGCSController::setAxisPositionCts(PIasynAxis* pAxis, double positio
 	double position = double(positionCts) * pAxis->m_CPUdenominator / pAxis->m_CPUnumerator;
 
 	asynPrint(m_pInterface->m_pCurrentLogSink, ASYN_TRACE_FLOW|ASYN_TRACE_ERROR,
-		"PIGCSController::setAxisPositionCts(, %d) \n", positionCts);
+		"PIGCSController::setAxisPositionCts(, %f) \n", positionCts);
 	return setAxisPosition(pAxis, position);
 }
 

--- a/motorApp/PIGCS2Src/PIInterface.cpp
+++ b/motorApp/PIGCS2Src/PIInterface.cpp
@@ -61,8 +61,8 @@ asynStatus PIInterface::sendOnly(const char *outputBuff, asynUser* logSink)
     if (status != asynSuccess)
     {
         asynPrint(logSink, ASYN_TRACE_ERROR|ASYN_TRACEIO_DRIVER,
-                  "PIGCSController:sendOnly: error sending command %s, sent=%d, status=%d\n",
-                  outputBuff, nActual, status);
+                  "PIGCSController:sendOnly: error sending command %s, sent=%ld, status=%d\n",
+                  outputBuff, (long)nActual, status);
     }
     return(status);
 }
@@ -83,8 +83,8 @@ asynStatus PIInterface::sendOnly(char c, asynUser* logSink)
     if (status != asynSuccess)
     {
         asynPrint(logSink, ASYN_TRACE_ERROR|ASYN_TRACEIO_DRIVER,
-                  "PIGCSController:sendOnly: error sending command %d, sent=%d, status=%d\n",
-                  int(c), nActual, status);
+                  "PIGCSController:sendOnly: error sending command %d, sent=%ld, status=%d\n",
+                  int(c), (long)nActual, status);
         //printf("PIInterface::sendOnly() sending \"#%d\"\n", int(c));
     }
     return(status);

--- a/motorApp/PIGCS2Src/PIasynController.cpp
+++ b/motorApp/PIGCS2Src/PIasynController.cpp
@@ -501,9 +501,7 @@ asynStatus PIasynController::poll()
 /** Configuration command, called directly or from iocsh */
 extern "C" int PI_GCS2_CreateController(const char *portName, const char* asynPort, int numAxes, int priority, int stackSize, int movingPollingRate, int idlePollingRate)
 {
-    PIasynController *pasynController
-        = new PIasynController(portName, asynPort, numAxes, priority, stackSize, movingPollingRate, idlePollingRate);
-    pasynController = NULL;
+    new PIasynController(portName, asynPort, numAxes, priority, stackSize, movingPollingRate, idlePollingRate);
     return(asynSuccess);
 }
 

--- a/motorApp/SmarActMCSSrc/smarActMCSMotorDriver.cpp
+++ b/motorApp/SmarActMCSSrc/smarActMCSMotorDriver.cpp
@@ -726,7 +726,6 @@ smarActMCSCreateAxis(
 void *rval = 0;
 
 SmarActMCSController *pC;
-SmarActMCSAxis *pAxis;
 asynMotorAxis *pAsynAxis;
 
 	// the asyn stuff doesn't seem to be prepared for exceptions. I get segfaults
@@ -753,8 +752,7 @@ asynMotorAxis *pAsynAxis;
 			return rval;
 		}
 		pC->lock();
-		pAxis = new SmarActMCSAxis(pC, axisNumber, channel);
-		pAxis = NULL;
+		new SmarActMCSAxis(pC, axisNumber, channel);
 		pC->unlock();
 
 #ifdef ASYN_CANDO_EXCEPTIONS


### PR DESCRIPTION
Remove compilation warning which should be treated as an error:
- printf ("%d", sizeof(nRead)"
  This did work on 32 bit systems, but not on 64 bit compilers.
  When size_t has 64 bit and %d takes only a 32 bit value from the
  stack, the printout is garbled and (in worst case) the machine
  can crash in theory.
  Even if I didn't check for "%d%s" combination, this is easy to fix
  by casting nRead to "long int" and use "%ld" to print it.

Remove minor compilation warnings:
- pAxis = new XXXH(this, axis); // pAxis is not needed. remove it
- Unused variables:
- This affects the following files:
  motorApp/AttocubeSrc/drvANC150Asyn.cc
  motorApp/MicronixSrc/MMC200Driver.cpp
  motorApp/OmsAsynSrc/omsBaseAxis.cpp
  motorApp/OmsAsynSrc/omsMAXnet.cpp
  motorApp/OmsAsynSrc/omsMAXnet.h
  motorApp/PIGCS2Src/PIGCSController.cpp
  motorApp/PIGCS2Src/PIInterface.cpp
  motorApp/PIGCS2Src/PIasynController.cpp
  motorApp/SmarActMCSSrc/smarActMCSMotorDriver.cpp
