### PR TITLE
NewportSrc: '#typedef' is not valid C-syntax

### DIFF
--- a/motorApp/NewportSrc/XPS_C8_drivers.cpp
+++ b/motorApp/NewportSrc/XPS_C8_drivers.cpp
@@ -28,7 +28,7 @@
 extern "C"
 {
 #else
-#typedef int bool;  /* C does not know bool, only C++ */
+typedef int bool;  /* C does not know bool, only C++ */
 #endif
 
 #define DLL_VERSION "Library version for XPS-C8 Firmware V2.6.x"

--- a/motorApp/NewportSrc/hxp_drivers.cpp
+++ b/motorApp/NewportSrc/hxp_drivers.cpp
@@ -28,7 +28,7 @@
 extern "C"
 {
 #else
-#typedef int bool;  /* C does not know bool, only C++ */
+typedef int bool;  /* C does not know bool, only C++ */
 #endif
 
 


### PR DESCRIPTION
Correct a typo:
is not valid C/C++ syntax.

Compiling with gcc 4.8.5 fails:
"invalid preprocessing directive #typedef"

Correct the line into typedef int bool;