### PR TITLE
Remove warnings in NewportSrc

### DIFF
--- a/motorApp/NewportSrc/HXPDriver.cpp
+++ b/motorApp/NewportSrc/HXPDriver.cpp
@@ -49,7 +49,6 @@ HXPController::HXPController(const char *portName, const char *IPAddress, int IP
                          0, 0)  // Default priority and stack size
 {
   int axis;
-  HXPAxis *pAxis;
   static const char *functionName = "HXPController::HXPController";
 
   axisNames_ = epicsStrDup("XYZUVW");
@@ -106,7 +105,7 @@ HXPController::HXPController(const char *portName, const char *IPAddress, int IP
   HXPFirmwareVersionGet(pollSocket_, firmwareVersion_);
 
   for (axis=0; axis<NUM_AXES; axis++) {
-    pAxis = new HXPAxis(this, axis);
+    new HXPAxis(this, axis);
   }
 
   startPoller(movingPollPeriod, idlePollPeriod, 2);
@@ -125,9 +124,7 @@ HXPController::HXPController(const char *portName, const char *IPAddress, int IP
 extern "C" int HXPCreateController(const char *portName, const char *IPAddress, int IPPort,
                                    int movingPollPeriod, int idlePollPeriod)
 {
-  HXPController *pHXPController
-    = new HXPController(portName, IPAddress, IPPort, movingPollPeriod/1000., idlePollPeriod/1000.);
-  pHXPController = NULL;
+  new HXPController(portName, IPAddress, IPPort, movingPollPeriod/1000., idlePollPeriod/1000.);
   return(asynSuccess);
 }
 
@@ -528,10 +525,9 @@ asynStatus HXPAxis::home(double baseVelocity, double slewVelocity, double accele
 
 asynStatus HXPAxis::stop(double acceleration )
 {
-  int status;
   //static const char *functionName = "HXPAxis::stop";
 
-  status = HXPGroupMoveAbort(moveSocket_, GROUP);
+  (void)HXPGroupMoveAbort(moveSocket_, GROUP);
 
   return asynSuccess;
 }

--- a/motorApp/NewportSrc/SMC100Driver.cpp
+++ b/motorApp/NewportSrc/SMC100Driver.cpp
@@ -49,7 +49,6 @@ SMC100Controller::SMC100Controller(const char *portName, const char *SMC100PortN
 {
   int axis;
   asynStatus status;
-  SMC100Axis *pAxis;
   static const char *functionName = "SMC100Controller::SMC100Controller";
   
   /* Connect to SMC100 controller */
@@ -61,7 +60,7 @@ SMC100Controller::SMC100Controller(const char *portName, const char *SMC100PortN
   }
   for (axis=0; axis<numAxes; axis++) {
   //for (axis=1; axis < (numAxes + 1); axis++) {
-    pAxis = new SMC100Axis(this, axis, stepSize);
+    new SMC100Axis(this, axis, stepSize);
   }
 
   startPoller(movingPollPeriod, idlePollPeriod, 2);

--- a/motorApp/NewportSrc/drvXPSAsyn.c
+++ b/motorApp/NewportSrc/drvXPSAsyn.c
@@ -1583,7 +1583,6 @@ int XPSConfigAxis(int card,                   /* specify which controller 0-up*/
     XPSController *pController;
     AXIS_HDL pAxis;
     char *index;
-    int status;
     double stepSize;
 
     if (numXPSControllers < 1) {
@@ -1614,12 +1613,12 @@ int XPSConfigAxis(int card,                   /* specify which controller 0-up*/
     stepSize = strtod(stepsPerUnit, NULL);
     pAxis->stepSize = 1./stepSize;
     /* Read some information from the controller for this axis */
-    status = PositionerSGammaParametersGet(pAxis->pollSocket,
-                                           pAxis->positionerName,
-                                           &pAxis->velocity,
-                                           &pAxis->accel,
-                                           &pAxis->minJerkTime,
-                                           &pAxis->maxJerkTime);
+    (void)PositionerSGammaParametersGet(pAxis->pollSocket,
+                                        pAxis->positionerName,
+                                        &pAxis->velocity,
+                                        &pAxis->accel,
+                                        &pAxis->minJerkTime,
+                                        &pAxis->maxJerkTime);
     pAxis->mutexId = epicsMutexMustCreate();
 
     /* Send a signal to the poller task which will make it do a poll, 


### PR DESCRIPTION
Remove compilation warnings:
-  pAxis = new XXXH(this, axis); // pAxis is not needed. remove it

- Unused variables:
  char *ptNext;
  ptNext = 0;
  While older compilers are OK with this, new compilers detect that the
  variable isnever used and give a warning.
  Remove the variable.
- status = XXX();
  status is never looked at.
  Remove it.
- Remove unused function

Note:
  Some castings from "string" into "char *" needs to be addressed later.