### PR TITLE
NewportSrc: size_t is not int

### DIFF
--- a/motorApp/NewportSrc/asynOctetSocket.cpp
+++ b/motorApp/NewportSrc/asynOctetSocket.cpp
@@ -179,7 +179,7 @@ void SendAndReceive (int SocketIndex, char buffer[], char valueRtrn[], int retur
                                             &eomReason);
             asynPrint(psock->pasynUser, ASYN_TRACEIO_DRIVER,
                   "SendAndReceive, received: nread=%d, returnSize-nread=%d, nbytesIn=%d\n",
-                  (int)nread, returnSize-nread, (int)nbytesIn);
+                  (int)nread, (int)(returnSize-nread), (int)nbytesIn);
             nread += nbytesIn;
         }
     } else {
@@ -260,7 +260,7 @@ int ReadXPSSocket (int SocketIndex, char valueRtrn[], int returnSize, double tim
                                         &eomReason);
         asynPrint(psock->pasynUser, ASYN_TRACEIO_DRIVER,
               "ReadXPSSocket, received: nread=%d, returnSize-nread=%d, nbytesIn=%d\n",
-              (int)nread, returnSize-nread, (int)nbytesIn);
+              (int)nread, (long)(returnSize-nread), (int)nbytesIn);
         nread += nbytesIn;
     } while ((status==asynSuccess) && 
              (strcmp(valueRtrn + nread - strlen(XPS_TERMINATOR), XPS_TERMINATOR) != 0));

--- a/motorApp/NewportSrc/drvMM4000Asyn.c
+++ b/motorApp/NewportSrc/drvMM4000Asyn.c
@@ -930,7 +930,7 @@ static int sendOnly(MM4000Controller *pController, char *outputBuff)
         {
             asynPrint(pController->pasynUser, ASYN_TRACE_ERROR,
                       "drvMM4000Asyn:sendOnly: error sending command %s, sent=%d, status=%d\n",
-                      outputBuff, nActual, status);
+                      outputBuff, (int)nActual, status);
         }
     }
     return(status);


### PR DESCRIPTION
NewportSrc: size_t is not int
    
    On a 64 bit Linux system the size of size_t is 64, not 32.
    Printing a variable of type size_t with %d does not work as expected.
    
    Solution: Cast the size_t into "int", which is big enough to hold the
    values we want to print.
