### PR TITLE
XPS: Arg2 mixed with Arg3

### DIFF
--- a/motorApp/NewportSrc/XPSController.cpp
+++ b/motorApp/NewportSrc/XPSController.cpp
@@ -1434,7 +1434,7 @@ static const iocshArg XPSCreateControllerArg7 = {"Set position settling time (ms
 static const iocshArg * const XPSCreateControllerArgs[] = {&XPSCreateControllerArg0,
                                                            &XPSCreateControllerArg1,
                                                            &XPSCreateControllerArg2,
-                                                           &XPSCreateControllerArg2,
+                                                           &XPSCreateControllerArg3,
                                                            &XPSCreateControllerArg4,
                                                            &XPSCreateControllerArg5,
                                                            &XPSCreateControllerArg6,

--- a/motorApp/NewportSrc/drvXPSAsyn.c
+++ b/motorApp/NewportSrc/drvXPSAsyn.c
@@ -2308,7 +2308,7 @@ static const iocshArg XPSConfigArg5 = {"Idle poll rate", iocshArgInt};
 static const iocshArg * const XPSConfigArgs[6] = {&XPSConfigArg0,
                                                   &XPSConfigArg1,
                                                   &XPSConfigArg2,
-                                                  &XPSConfigArg2,
+                                                  &XPSConfigArg3,
                                                   &XPSConfigArg4,
                                                   &XPSConfigArg5};
 static const iocshFuncDef configXPS = {"XPSConfig", 6, XPSConfigArgs};


### PR DESCRIPTION
Both  XPSCreateControllerArgs and XPSConfigArgs did mix up Args3 with Args2:
Instead of Args3 Args2 was used.

Fix it.