### PR TITLE
ignore SET field, so a database can do it instead

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -1378,7 +1378,7 @@ enter_do_work:
     if (pmr->lvio != old_lvio)
     {
         MARK(M_LVIO);
-        if (pmr->lvio && !pmr->set)
+        if (pmr->lvio && (!pmr->set && !pmr->igset))
         {
             pmr->stop = 1;
             MARK(M_STOP);
@@ -1868,7 +1868,7 @@ static RTN_STATUS do_work(motorRecord * pmr, CALLBACK_VALUE proc_ind)
             WRITE_MSG(SET_ENC_RATIO, ep_mp);
             SEND_MSG();
         }
-        if (pmr->set)
+        if (pmr->set && !pmr->igset)
         {
             pmr->pp = TRUE;
             INIT_MSG();
@@ -2082,7 +2082,7 @@ static RTN_STATUS do_work(motorRecord * pmr, CALLBACK_VALUE proc_ind)
     if (pmr->val != pmr->lval)
     {
         MARK(M_VAL);
-        if (set && !pmr->foff)
+        if ((set && !pmr->igset) && !pmr->foff)
         {
             /*
              * Act directly on .val. and return. User wants to redefine .val
@@ -2132,7 +2132,7 @@ static RTN_STATUS do_work(motorRecord * pmr, CALLBACK_VALUE proc_ind)
 
         pmr->rdif = NINT(pmr->diff / pmr->mres);
         MARK(M_RDIF);
-        if (set)
+        if (set && !pmr->igset)
         {
             if ((pmr->mip & MIP_LOAD_P) == 0) /* Test for LOAD_POS completion. */
                 load_pos(pmr);

--- a/motorApp/MotorSrc/motorRecord.dbd
+++ b/motorApp/MotorSrc/motorRecord.dbd
@@ -788,4 +788,8 @@ recordtype(motor) {
 		pp(TRUE)
 		interest(1)
 	}
+	field(IGSET,DBF_SHORT) {
+		prompt("Ignore SET field")
+		interest(2)
+	}
 }


### PR DESCRIPTION
When a soft motor record is driving a database, it's sometimes desirable for the database to be able to implement SET/USE operations, instead of having the soft motor record do them internally.  When IGSET==1, the motor record will behave as though SET==0, no matter what the actual value of SET is.  Then the database can monitor the SET field, and handle any changes to VAL while SET==1 as it wishes - for example, by forwarding them to a downstream hard motor.