### PR TITLE
Record recognizes motor stop while jogging

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -1272,8 +1272,18 @@ static long process(dbCommon *arg)
             /* Assume we're done moving until we find out otherwise. */
             if (pmr->dmov == FALSE)
             {
+                Debug(3, "%s:%d motor has stopped pp=%d mip=0x%0x\n",
+                      __FILE__, __LINE__, pmr->pp, pmr->mip);
                 pmr->dmov = TRUE;
                 MARK(M_DMOV);
+                if (pmr->mip == MIP_JOGF || pmr->mip == MIP_JOGR)
+                {
+                    /* Motor stopped while jogging and we didn't stop it */
+                    pmr->mip = MIP_DONE;
+                    MARK(M_MIP);
+                    clear_buttons(pmr);
+                    pmr->pp = TRUE;
+                }
             }
 
             /* Do another update after LS error. */


### PR DESCRIPTION
The following situation came up while debugging soft limits in a
motion controller which had different values then the record.

The motor is at position 50mm (RBV=50), the low soft limit is 15 (LLM=15),
jogging velocity is 10 mm/sec (JVEL=10).

The motion controller has an internal soft limit which is 35 mm, which
we want to test.
Set JOGR to 1, the motor will move backwards.
(Side note: it would be stopped by the record once it passed 25mm).

Before that, the motion controller stops the motor internally and reports DONE.
The state machine in the record is not prepared to handle this and JOGR stays 1.
The expected behavior is that JOGR returns to 0.
Because this is an unexpected stop, reset even pending home requests.
In other words: call clear_buttons(pmr)

Whether or not an alarm is raised may be another question.
The natural thing would be to set LVIO to 1, but we don't know why the controller
stopped the motion.
Unless we add a bit in MSTA like "RA_LVIO"...
But in any case this can and should go into a separate commit.