### PR TITLE
Record: motor record DLY and STOP problem

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -1792,9 +1792,13 @@ static RTN_STATUS do_work(motorRecord * pmr, CALLBACK_VALUE proc_ind)
             /* Cancel any operations. */
             if (pmr->mip & MIP_HOME)
                 clear_buttons(pmr);
-            
-            pmr->mip = MIP_STOP;
-            MARK(M_MIP);
+
+            if (!(pmr->mip & MIP_DELAY_REQ)) {
+               /* When we wait for DLY, keep it. */
+               /* Otherwise the record may lock up */
+                pmr->mip = MIP_STOP;     
+                MARK(M_MIP);
+            }
             INIT_MSG();
             WRITE_MSG(STOP_AXIS, NULL);
             SEND_MSG();


### PR DESCRIPTION
Fix the problem that the record gets stuck when STOP is
pressed while the record is in MIP_DELAY (and the motor
is standing still, so that there is no record processing).

Currently the MIP_DELAY bits are set to 0, when a STOP is issued.
As the motor already hase stopped, the DMOV field never goes to 1.
There are 2 possible solutions here:
a) STOP wins:
  pmr->dmov = FALSE;
  MARK(M_DMOV);

b) DELAY wins
  Send a STOP to the controller (just to be sure), but wait for the DELAY.

a) may cause probles later, whena new positionioning is done after the STOP
and a new DELAY is triggered.
As the old callback is still active, it may be executed before the new
callback. And the time will be too short.
For this reason go with b)

http://www.aps.anl.gov/epics/tech-talk/2015/msg01786.php