### PR TITLE
Zero base Velocity, ZeroVbas

### DIFF
--- a/documentation/motorRecord.html
+++ b/documentation/motorRecord.html
@@ -2533,6 +2533,9 @@ below.
 	  <li>
 	    HOMED: the motor has been homed.<br>
 	  </li>
+	  <li>
+	    ZEROVBAS: the motor does not support VBAS.<br>
+	  </li>
 	</ol>
 	The record is put into MAJOR STATE alarm if either SLIP_STALL or PROBLEM bits are detected. 
 	If HLSV is set, then the record is put into HIGH alarm if either a high soft limit or 

--- a/motorApp/MotorSrc/asynMotorAxis.cpp
+++ b/motorApp/MotorSrc/asynMotorAxis.cpp
@@ -237,7 +237,7 @@ int  asynMotorAxis::getReferencingModeMove()
 
 /** Sets the value for an integer for this axis in the parameter library.
   * This function takes special action if the parameter is one of the motorStatus parameters
-  * (motorStatusDirection_, motorStatusHomed_, etc.).  In that case it sets or clears the appropriate
+  * (motorStatusDirection_, motorStatusZeroVbas_, etc.).  In that case it sets or clears the appropriate
   * bit in its private MotorStatus.status structure and if that status has changed sets a flag to
   * do callbacks to devMotorAsyn when callParamCallbacks() is called.
   * \param[in] function The function (parameter) number 
@@ -248,7 +248,7 @@ asynStatus asynMotorAxis::setIntegerParam(int function, int value)
   epicsUInt32 status=0;
   // This assumes the parameters defined above are in the same order as the bits the motor record expects!
   if (function >= pC_->motorStatusDirection_ && 
-      function <= pC_->motorStatusHomed_) {
+      function <= pC_->motorStatusZeroVbas_) {
     status = status_.status;
     mask = 1 << (function - pC_->motorStatusDirection_);
     if (value) status |= mask;

--- a/motorApp/MotorSrc/asynMotorController.cpp
+++ b/motorApp/MotorSrc/asynMotorController.cpp
@@ -86,6 +86,7 @@ asynMotorController::asynMotorController(const char *portName, int numAxes, int 
   createParam(motorStatusCommsErrorString,       asynParamInt32,      &motorStatusCommsError_);
   createParam(motorStatusLowLimitString,         asynParamInt32,      &motorStatusLowLimit_);
   createParam(motorStatusHomedString,            asynParamInt32,      &motorStatusHomed_);
+  createParam(motorStatusZeroVbasString,         asynParamInt32,      &motorStatusZeroVbas_);
 
   // These are per-axis parameters for passing additional motor record information to the driver
   createParam(motorRecResolutionString,        asynParamFloat64,      &motorRecResolution_);

--- a/motorApp/MotorSrc/asynMotorController.h
+++ b/motorApp/MotorSrc/asynMotorController.h
@@ -60,6 +60,7 @@
 #define motorStatusCommsErrorString     "MOTOR_STATUS_COMMS_ERROR"
 #define motorStatusLowLimitString       "MOTOR_STATUS_LOW_LIMIT"
 #define motorStatusHomedString          "MOTOR_STATUS_HOMED"
+#define motorStatusZeroVbasString       "MOTOR_STATUS_ZERO_VBAS"
 
 /* These are per-axis parameters for passing additional motor record information to the driver */
 #define motorRecResolutionString        "MOTOR_REC_RESOLUTION"
@@ -244,6 +245,7 @@ class epicsShareClass asynMotorController : public asynPortDriver {
   int motorStatusCommsError_;
   int motorStatusLowLimit_;
   int motorStatusHomed_;
+  int motorStatusZeroVbas_;
 
   // These are per-axis parameters for passing additional motor record information to the driver
   int motorRecResolution_;

--- a/motorApp/MotorSrc/drvMotorAsyn.c
+++ b/motorApp/MotorSrc/drvMotorAsyn.c
@@ -94,7 +94,7 @@ typedef enum {
     motorStatusSlip, motorStatusPowerOn, motorStatusFollowingError,
     motorStatusHome, motorStatusHasEncoder, motorStatusProblem,
     motorStatusMoving, motorStatusGainSupport, motorStatusCommsError,
-    motorStatusLowLimit, motorStatusHomed, motorStatusLast,
+    motorStatusLowLimit, motorStatusHomed, motorStatusZeroVbas, motorStatusLast,
     /* Not exposed by the driver */
     motorVelocity=100, motorVelBase, motorAccel, 
     /* Commands */
@@ -147,6 +147,7 @@ static motorCommandStruct motorCommands[] = {
     {motorStatusCommsError,     motorStatusCommsErrorString},
     {motorStatusLowLimit,       motorStatusLowLimitString},
     {motorStatusHomed,          motorStatusHomedString},
+    {motorStatusZeroVbas,       motorStatusZeroVbasString},
 };
 
 typedef enum{typeInt32, typeFloat64, typeFloat64Array} dataType;

--- a/motorApp/MotorSrc/motor.h
+++ b/motorApp/MotorSrc/motor.h
@@ -158,7 +158,8 @@ typedef union
     struct
     {
 #ifdef MSB_First
-        unsigned int na             :17;/* N/A bits  */
+        unsigned int na             :16;/* N/A bits  */
+        unsigned int RA_ZERO_VBAS   :1; /* VBAS not supported, set to 0 */
         unsigned int RA_HOMED       :1; /* Axis has been homed.*/
         unsigned int RA_MINUS_LS    :1; /* minus limit switch has been hit */
         unsigned int CNTRL_COMM_ERR :1; /* Controller communication error. */
@@ -190,7 +191,8 @@ typedef union
         unsigned int CNTRL_COMM_ERR :1; /* Controller communication error. */
         unsigned int RA_MINUS_LS    :1; /* minus limit switch has been hit */
         unsigned int RA_HOMED       :1; /* Axis has been homed.*/
-        unsigned int na             :17;/* N/A bits  */
+        unsigned int RA_ZERO_VBAS   :1; /* VBAS not supported, set to 0 */
+        unsigned int na             :16;/* N/A bits  */
 #endif
     } Bits;                                
 } msta_field;

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -1197,7 +1197,15 @@ static long process(dbCommon *arg)
      */
     process_reason = (*pdset->update_values) (pmr);
     if (pmr->msta != old_msta)
+    {
+        msta_field msta;
+        msta.All = pmr->msta;
         MARK(M_MSTA);
+        if (msta.Bits.RA_ZERO_VBAS && pmr->vbas)
+        {
+            pmr->sbas = pmr->vbas = 0.0;
+        }
+    }
 
     if ((process_reason == CALLBACK_DATA) || (pmr->mip & MIP_DELAY_ACK))
     {
@@ -2431,6 +2439,10 @@ static long special(DBADDR *paddr, int after)
     msta_field msta;
 
     msta.All = pmr->msta;
+    if (msta.Bits.RA_ZERO_VBAS)
+    {
+        pmr->sbas = pmr->vbas = 0.0;
+    }
 
     Debug(3, "special: after = %d\n", after);
 
@@ -3763,6 +3775,8 @@ static void load_pos(motorRecord * pmr)
 static void check_speed_and_resolution(motorRecord * pmr)
 {
     double fabs_urev = fabs(pmr->urev);
+    msta_field msta;
+    msta.All = pmr->msta;
 
     /*
      * Reconcile two different ways of specifying speed, resolution, and make
@@ -3804,6 +3818,10 @@ static void check_speed_and_resolution(motorRecord * pmr)
     db_post_events(pmr, &pmr->vmax, DBE_VAL_LOG);
     db_post_events(pmr, &pmr->smax, DBE_VAL_LOG);
 
+    if (msta.Bits.RA_ZERO_VBAS)
+    {
+        pmr->sbas = pmr->vbas = 0.0;
+    }
     /* SBAS (revolutions/sec) <--> VBAS (EGU/sec) */
     if (pmr->sbas != 0.0)
     {


### PR DESCRIPTION
Whenever a controller does not use VBAS, but the field is
set to some value != 0.0 in the record, the calculation of the
acceleration parameters is wrong:

The record assumes that the axis jumps to VBAS in zero time, and ramps
up to e.g. VELO with the acceleration specified.

One improvement has already been mad when VELO == VBAS,
see commit b201e40ee3, "Changed ACCL calculation when VELO == VBAS."

Now we make another improvement: the driver can tell the record to set VBAS
to 0.0.

This is done by setting by setting bit 15 (counted from 0) in MSTA:
"This axis doesn't support VBAS at all, so please set it to 0".