### PR TITLE
Fix issue with power being left on when using autoPower option in asy…

### DIFF
--- a/motorApp/MotorSrc/asynMotorController.cpp
+++ b/motorApp/MotorSrc/asynMotorController.cpp
@@ -280,6 +280,7 @@ asynStatus asynMotorController::writeFloat64(asynUser *pasynUser, epicsFloat64 v
   if (function == motorMoveRel_) {
     if (autoPower == 1) {
       status = pAxis->setClosedLoop(true);
+      pAxis->setWasMovingFlag(1);
       epicsThreadSleep(autoPowerOnDelay);
     }
     getDoubleParam(axis, motorVelBase_, &baseVelocity);
@@ -296,6 +297,7 @@ asynStatus asynMotorController::writeFloat64(asynUser *pasynUser, epicsFloat64 v
   } else if (function == motorMoveAbs_) {
     if (autoPower == 1) {
       status = pAxis->setClosedLoop(true);
+      pAxis->setWasMovingFlag(1);
       epicsThreadSleep(autoPowerOnDelay);
     }
     getDoubleParam(axis, motorVelBase_, &baseVelocity);
@@ -312,6 +314,7 @@ asynStatus asynMotorController::writeFloat64(asynUser *pasynUser, epicsFloat64 v
   } else if (function == motorMoveVel_) {
     if (autoPower == 1) {
       status = pAxis->setClosedLoop(true);
+      pAxis->setWasMovingFlag(1);
       epicsThreadSleep(autoPowerOnDelay);
     }
     getDoubleParam(axis, motorVelBase_, &baseVelocity);
@@ -328,6 +331,7 @@ asynStatus asynMotorController::writeFloat64(asynUser *pasynUser, epicsFloat64 v
   } else if (function == motorHome_) {
     if (autoPower == 1) {
       status = pAxis->setClosedLoop(true);
+      pAxis->setWasMovingFlag(1);
       epicsThreadSleep(autoPowerOnDelay);
     }
     getDoubleParam(axis, motorVelBase_, &baseVelocity);


### PR DESCRIPTION
…nMotorController. This could happen if the motor doesn't move because it's already in position, so the poller doesn't detect a move.

This is a re-submit of an old pull request (#17)