### PR TITLE
Fix problems with devESP300 and drvESP300

### DIFF
--- a/motorApp/NewportSrc/devESP300.cc
+++ b/motorApp/NewportSrc/devESP300.cc
@@ -240,7 +240,7 @@ static RTN_STATUS ESP300_build_trans(motor_cmnd command, double *parms, struct m
 	    sprintf(buff, "%.2dVA%f;", axis, cntrl_units);
 	    break;
 	case SET_ACCEL:
-	    sprintf(buff, "%.2dAC%f;", axis, cntrl_units);
+	    sprintf(buff, "%.2dAC%f;%.2dAG%f;", axis, cntrl_units, axis, cntrl_units);
 	    break;
 	case GO:
 	    /* 


### PR DESCRIPTION
Problem with devESP300.cc
- The ESP300 has independent settings for the acceleration and deceleration.  These are set with the AC and AG commands respectively.  However, when setting the acceleration device support was previously only sending AC, not AG.  Thus the deceleration value used was whatever was saved in the ESP300 non-volatile settings.  This fix sends the AG command with the same value as the AC command.

Problem with drvESP300.cc
- The drive_resolution variable in the driver is used to convert from motor record steps to controller engineering units.  Previously drive_resolution was being set by reading the value of the SU? command.  This returns the encoder resolution.  However, for open-loop stepper motors this value is not defined, and I could find no way to set it in the controller.  I changed the driver as follows:
  - Use the ZB? command to see if stepper positioning is enabled and encoder feedback is disabled.
  - If so the full-step (FR?) and microstep (QS?) values are used to determine drive_resolution.
  - If not then SU? is used to determine drive resolution, as previously.

This pull-request should be merged before the gcc-fix branch, it does not have those changes in it.

