### PR TITLE
Added I/O flush before first query (Micronix MMC-x00)

### DIFF
--- a/motorApp/MicronixSrc/MMC200Driver.cpp
+++ b/motorApp/MicronixSrc/MMC200Driver.cpp
@@ -136,6 +136,9 @@ MMC200Axis::MMC200Axis(MMC200Controller *pC, int axisNo)
   // controller axes are numbered from 1
   axisIndex_ = axisNo + 1;
 
+  // Flush I/O in case there is lingering garbage
+  pC_->writeReadController();
+  
   // Read the version string to determine controller model (200/100)
   sprintf(pC_->outString_, "%dVER?", axisIndex_);
   status = pC_->writeReadController();


### PR DESCRIPTION
In testing an MMC-200 connected via USB, this added flush helped make sure the initial 'VER?' query went through properly.