### PR TITLE
Added support for AMCI ANF controllers

### DIFF
--- a/documentation/motorRecord.html
+++ b/documentation/motorRecord.html
@@ -117,6 +117,9 @@ Channel support):
   <li>
     Phytron I1AM01 Stepper Motor Controller.
   </li>
+  <li>
+    AMCI ANG1 Stepper Motor Controller/Driver, ANF1E/ANF1/ANF2E/ANF2 Stepper Motor Controllers.
+  </li>
 </ul>
 The record maintains two coordinate systems for motor position ("user" and "dial 
 " coordinates); displays drive and readback values; enforces limits to motor 

--- a/iocBoot/iocWithAsyn/motor.cmd.ANF2
+++ b/iocBoot/iocWithAsyn/motor.cmd.ANF2
@@ -50,8 +50,7 @@ dbLoadTemplate("templates/motor.substitutions.ANF2")
 #    portName,        The name of the asyn port that will be created by this driver
 #    ANF2InPortName,  The name of the In drvAsynIPPPort to read from the ANF2 controller
 #    ANF2OutPortName, The name of the Out drvAsynIPPPort to write to the ANF2 controller
-#    numModules,      The number of modules in the stack (Max=6)
-#    axesPerModule)   The number of axes per module (ANF1=1, ANF2=2)
+#    numAxes)         The number of axes in the stack (max=12)
 #  
 #  ANF2CreateAxis(
 #    ANF2Name,        The controller's asyn port
@@ -64,10 +63,10 @@ dbLoadTemplate("templates/motor.substitutions.ANF2")
 #    does correct the acceleration sent by the motor record to give the desired acceleration time.
 
 # Controller 1 (One ANF2E, Five ANF2's)
-ANF2CreateController("$(PORT1)", "$(PORT1)_In", "$(PORT1)_Out", 6, 2)
+ANF2CreateController("$(PORT1)", "$(PORT1)_In", "$(PORT1)_Out", 12)
 # Axes for Controller 1
 ANF2CreateAxis("$(PORT1)", 0,  "0x86280000", 100, 0)
-ANF2CreateAxis("$(PORT1)", 1,  "0x86000000", 57, 32)
+ANF2CreateAxis("$(PORT1)", 1,  "0x86000000", 100, 0)
 ANF2CreateAxis("$(PORT1)", 2,  "0x84000000", 100, 0)
 ANF2CreateAxis("$(PORT1)", 3,  "0x84000000", 100, 0)
 ANF2CreateAxis("$(PORT1)", 4,  "0x84000000", 100, 0)
@@ -80,7 +79,7 @@ ANF2CreateAxis("$(PORT1)", 10, "0x84000000", 100, 0)
 ANF2CreateAxis("$(PORT1)", 11, "0x84000000", 100, 0)
 
 # Controller 2 (One ANF1E, Five ANF1's)
-ANF2CreateController("$(PORT2)", "$(PORT2)_In", "$(PORT2)_Out", 6, 1)
+ANF2CreateController("$(PORT2)", "$(PORT2)_In", "$(PORT2)_Out", 6)
 # Axes for Controller 2
 ANF2CreateAxis("$(PORT2)", 0, "0x84000000", 100, 0)
 ANF2CreateAxis("$(PORT2)", 1, "0x84000000", 100, 0)

--- a/iocBoot/iocWithAsyn/motor.cmd.ANF2
+++ b/iocBoot/iocWithAsyn/motor.cmd.ANF2
@@ -9,8 +9,8 @@ epicsEnvSet("PORT1", "ANF2_C1")
 epicsEnvSet("PORT2", "ANF2_C2")
 
 # drvAsynIPPortConfigure("portName", "hostInfo", priority, noAutoConnect, noProcessEos);
-drvAsynIPPortConfigure("$(PORT1)_IP","192.168.1.101:502",0,0,1)
-drvAsynIPPortConfigure("$(PORT2)_IP","192.168.1.102:502",0,0,1)
+drvAsynIPPortConfigure("$(PORT1)_IP","192.168.0.50:502",0,0,1)
+drvAsynIPPortConfigure("$(PORT2)_IP","192.168.0.51:502",0,0,1)
 
 # modbusInterposeConfig("portName", linkType, timeoutMsec, writeDelayMsec)
 modbusInterposeConfig("$(PORT1)_IP",0,2000,0)

--- a/iocBoot/iocWithAsyn/motor.cmd.ANF2
+++ b/iocBoot/iocWithAsyn/motor.cmd.ANF2
@@ -1,0 +1,108 @@
+# ANF2 motors command file example (run in iocsh)
+#
+### Note:  Modbus support (the EPICS modbus module) is required to be included in the 
+###        EPICS application where the ANF2 support will be loaded.  This file is an 
+###        example of how to load the ANF2 support, in an ioc that is built with the 
+###        EPICS modbus module.
+
+epicsEnvSet("PORT1", "ANF2_C1")
+epicsEnvSet("PORT2", "ANF2_C2")
+
+# drvAsynIPPortConfigure("portName", "hostInfo", priority, noAutoConnect, noProcessEos);
+drvAsynIPPortConfigure("$(PORT1)_IP","192.168.1.101:502",0,0,1)
+drvAsynIPPortConfigure("$(PORT2)_IP","192.168.1.102:502",0,0,1)
+
+# modbusInterposeConfig("portName", linkType, timeoutMsec, writeDelayMsec)
+modbusInterposeConfig("$(PORT1)_IP",0,2000,0)
+modbusInterposeConfig("$(PORT2)_IP",0,2000,0)
+
+# NOTE: modbusLength = 10 * number of axes
+# drvModbusAsynConfigure("portName", "tcpPortName", slaveAddress, modbusFunction, 
+#                        modbusStartAddress, modbusLength, dataType, pollMsec, "plcType")
+drvModbusAsynConfigure("$(PORT1)_In", "$(PORT1)_IP", 0, 4, 0, 120, 0, 100, "ANF2_stepper")
+drvModbusAsynConfigure("$(PORT2)_In", "$(PORT2)_IP", 0, 4, 0,  60, 0, 100, "ANF2_stepper")
+
+# NOTE: modbusLength = 10 * number of axes
+# drvModbusAsynConfigure("portName", "tcpPortName", slaveAddress, modbusFunction, 
+#                        modbusStartAddress, modbusLength, dataType, pollMsec, "plcType")
+drvModbusAsynConfigure("$(PORT1)_Out", "$(PORT1)_IP", 0, 16, 1024, 120, 6, 1, "ANF2_stepper")
+drvModbusAsynConfigure("$(PORT2)_Out", "$(PORT2)_IP", 0, 16, 1024,  60, 6, 1, "ANF2_stepper")
+
+# Asyn traces for debugging
+#!asynSetTraceIOMask "$(PORT1)_In",0,4
+#!asynSetTraceMask "$(PORT1)_In",0,9
+#!asynSetTraceIOMask "$(PORT1)_Out",0,4
+#!asynSetTraceMask "$(PORT1)_Out",0,9
+#!asynSetTraceInfoMask "$(PORT1)_Out",0,15
+
+# Asyn records for debugging
+#!dbLoadRecords("$(ASYN)/db/asynRecord.db","P=IOC:,R=asyn:c1ip,PORT=$(PORT1)_IP,ADDR=0,OMAX=256,IMAX=256")
+#!dbLoadRecords("$(ASYN)/db/asynRecord.db","P=IOC:,R=asyn:c1in,PORT=$(PORT1)_In,ADDR=0,OMAX=256,IMAX=256")
+#!dbLoadRecords("$(ASYN)/db/asynRecord.db","P=IOC:,R=asyn:c1out,PORT=$(PORT1)_Out,ADDR=0,OMAX=256,IMAX=256")
+#!dbLoadRecords("$(ASYN)/db/asynRecord.db","P=IOC:,R=asyn:c1,PORT=$(PORT1),ADDR=0,OMAX=256,IMAX=256")
+
+# Load the motor records
+dbLoadTemplate("templates/motor.substitutions.ANF2")
+
+# AMCI ANF2 stepper controller driver support
+#
+#  ANF2CreateController(
+#    portName,        The name of the asyn port that will be created by this driver
+#    ANF2InPortName,  The name of the In drvAsynIPPPort to read from the ANF2 controller
+#    ANF2OutPortName, The name of the Out drvAsynIPPPort to write to the ANF2 controller
+#    numModules,      The number of modules in the stack (Max=6)
+#    axesPerModule)   The number of axes per module (ANF1=1, ANF2=2)
+#  
+#  ANF2CreateAxis(
+#    ANF2Name,        The controller's asyn port
+#    axis,            The axis to be configured (zero-based numbering)
+#    hexConfig,       The desired hex configuration (see manual & AMCI Net Configurator for details)
+#    baseSpeed,       The base speed (steps/second; min=1, max=1,000,000)
+#    homingTimeout)   The homing timeout (integer number of seconds; min=0, max=300)
+#
+#  Note: The base speed can't be changed using the VBAS field of the motor record, but the driver
+#    does correct the acceleration sent by the motor record to give the desired acceleration time.
+
+# Controller 1 (One ANF2E, Five ANF2's)
+ANF2CreateController("$(PORT1)", "$(PORT1)_In", "$(PORT1)_Out", 6, 2)
+# Axes for Controller 1
+ANF2CreateAxis("$(PORT1)", 0,  "0x86280000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 1,  "0x86000000", 57, 32)
+ANF2CreateAxis("$(PORT1)", 2,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 3,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 4,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 5,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 6,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 7,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 8,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 9,  "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 10, "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT1)", 11, "0x84000000", 100, 0)
+
+# Controller 2 (One ANF1E, Five ANF1's)
+ANF2CreateController("$(PORT2)", "$(PORT2)_In", "$(PORT2)_Out", 6, 1)
+# Axes for Controller 2
+ANF2CreateAxis("$(PORT2)", 0, "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT2)", 1, "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT2)", 2, "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT2)", 3, "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT2)", 4, "0x84000000", 100, 0)
+ANF2CreateAxis("$(PORT2)", 5, "0x84000000", 100, 0)
+
+# NOTE: the poller needs to be started after iocInit
+
+
+
+##########
+# iocInit
+##########
+
+
+
+# ANF2StartPoller(
+#   portName,         The controller's asyn port
+#   movingPollPeriod, The time in ms between polls when any axis is moving
+#   idlePollPeriod)   The time in ms between polls when no axis is moving
+#
+ANF2StartPoller("$(PORT1)", 200, 1000)
+ANF2StartPoller("$(PORT2)", 200, 1000)

--- a/iocBoot/iocWithAsyn/motor.substitutions.ANF2
+++ b/iocBoot/iocWithAsyn/motor.substitutions.ANF2
@@ -1,0 +1,54 @@
+file "$(MOTOR)/motorApp/Db/asyn_motor.db"
+{
+pattern
+{P,        M,         DTYP,      PORT,   ADDR,   DESC,          EGU,    DIR,  VELO,  VBAS,  ACCL,  BDST,  BVEL,  BACC,  MRES,  PREC,  DHLM,  DLLM,  INIT, RTRY}
+
+{IOC:,  "m1",  "asynMotor",  "ANF2_C1",  0,  "ANF2 C1 M1",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m2",  "asynMotor",  "ANF2_C1",  1,  "ANF2 C1 M2",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m3",  "asynMotor",  "ANF2_C1",  2,  "ANF2 C1 M3",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m4",  "asynMotor",  "ANF2_C1",  3,  "ANF2 C1 M4",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m5",  "asynMotor",  "ANF2_C1",  4,  "ANF2 C1 M5",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m6",  "asynMotor",  "ANF2_C1",  5,  "ANF2 C1 M6",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m7",  "asynMotor",  "ANF2_C1",  6,  "ANF2 C1 M7",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m8",  "asynMotor",  "ANF2_C1",  7,  "ANF2 C1 M8",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:,  "m9",  "asynMotor",  "ANF2_C1",  8,  "ANF2 C1 M9",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m10",  "asynMotor",  "ANF2_C1",  9,  "ANF2 C1 M10",  steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m11",  "asynMotor",  "ANF2_C1", 10,  "ANF2 C1 M11",  steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m12",  "asynMotor",  "ANF2_C1", 11,  "ANF2 C1 M12",  steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+
+{IOC:, "m13",  "asynMotor",  "ANF2_C2",  0,  "ANF2 C2 M1",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m14",  "asynMotor",  "ANF2_C2",  1,  "ANF2 C2 M2",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m15",  "asynMotor",  "ANF2_C2",  2,  "ANF2 C2 M3",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m16",  "asynMotor",  "ANF2_C2",  3,  "ANF2 C2 M4",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m17",  "asynMotor",  "ANF2_C2",  4,  "ANF2 C2 M5",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+{IOC:, "m18",  "asynMotor",  "ANF2_C2",  5,  "ANF2 C2 M6",   steps,  Pos,  100,     0,    .2,    0,     50,     .2,  1,  5,     1e9,   -1e9,  ""}
+
+}
+
+file "$(MOTOR)/motorApp/Db/ANF2Aux.template"
+{
+pattern
+{P,     R,        PORT,    ADDR}
+
+{IOC:,  m1:,   "ANF2_C1",  0}
+{IOC:,  m2:,   "ANF2_C1",  1}
+{IOC:,  m3:,   "ANF2_C1",  2}
+{IOC:,  m4:,   "ANF2_C1",  3}
+{IOC:,  m5:,   "ANF2_C1",  4}
+{IOC:,  m6:,   "ANF2_C1",  5}
+{IOC:,  m7:,   "ANF2_C1",  6}
+{IOC:,  m8:,   "ANF2_C1",  7}
+{IOC:,  m9:,   "ANF2_C1",  8}
+{IOC:,  m10:,  "ANF2_C1",  9}
+{IOC:,  m11:,  "ANF2_C1",  10}
+{IOC:,  m12:,  "ANF2_C1",  11}
+
+{IOC:,  m13:,  "ANF2_C2",  0}
+{IOC:,  m14:,  "ANF2_C2",  1}
+{IOC:,  m15:,  "ANF2_C2",  2}
+{IOC:,  m16:,  "ANF2_C2",  3}
+{IOC:,  m17:,  "ANF2_C2",  4}
+{IOC:,  m18:,  "ANF2_C2",  5}
+
+}
+

--- a/motorApp/AMCISrc/AMCISupport.dbd
+++ b/motorApp/AMCISrc/AMCISupport.dbd
@@ -1,0 +1,2 @@
+include "ANG1Support.dbd"
+include "ANF2Support.dbd"

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -732,11 +732,14 @@ asynStatus ANF2Axis::home(double minVelocity, double maxVelocity, double acceler
   // This sets indices 2 & 3 of motionReg_
   status = sendAccelAndVelocity(acceleration, maxVelocity);
 
+  // Note: if the home input is active when the home command is sent, the axis will appear to move in the wrong direction
   if (forwards) {
     printf(" ** HOMING FORWARDS **\n");
+    // The +Find Home (CW) command
     motionReg_[0] = 0x20 << 16;
   } else {
     printf(" ** HOMING REVERSE **\n");
+    // The -Find Home (CCW) command 
     motionReg_[0] = 0x40 << 16;
   }
 

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -344,7 +344,7 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   registers_[1] = 0x00000064;
   
   // Does the number of elements refer to the number of 16-bit elements?
-  status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
+  //status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
   // Mabye do it this way in the future
   //status = this->pC_->writeReg32Array(axisNo, CONFIG_MSW, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
   // Write all the registers

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -404,6 +404,14 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32
   // Delay
   //epicsThreadSleep(1.0);
   
+  // Initialize parameters to avoid ASYN_TRACE_FLOW errors
+  setIntegerParam(pC_->motorStatusDirection_, 1);
+  // The following are necessary after this commit: 
+  //    https://github.com/epics-modules/motor/commit/36dfab4a78725866fab5bd212c4c128a86e9f044
+  setIntegerParam(pC_->motorPowerAutoOnOff_, 0);
+  setDoubleParam(pC_->motorPowerOnDelay_, 0.0);
+  setDoubleParam(pC_->motorPowerOffDelay_, 0.0);
+  
   // Tell the driver the axis has been created
   pC_->axesCreated_ += 1;
   

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -56,7 +56,7 @@ ANF2Controller::ANF2Controller(const char *portName, const char *ANF2InPortName,
   // Create controller-specific parameters
   createParam(ANF2ResetErrorsString,     asynParamInt32,       &ANF2ResetErrors_);
   createParam(ANF2GetInfoString,         asynParamInt32,       &ANF2GetInfo_);
-  createParam(ANF2ReconfigString,        asynParamInt32,       &ANF2Reconfig_);
+  //createParam(ANF2ReconfigString,        asynParamInt32,       &ANF2Reconfig_);
 
   numModules_ = numModules;
   axesPerModule_ = axesPerModule;
@@ -247,10 +247,12 @@ asynStatus ANF2Controller::writeInt32(asynUser *pasynUser, epicsInt32 value)
         pAxis->getInfo();
 
     }
+  /*
   } else if (function == ANF2Reconfig_)
   {
     // reconfig regardless of the value
     pAxis->reconfig(value);
+  */
   } else {
   // Call base class method
     status = asynMotorController::writeInt32(pasynUser, value);
@@ -338,10 +340,9 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32
   //printf("ANF2Axis::ANF2Axis : pasynUserForceRead_->reason=%d\n", pasynUserForceRead_->reason);
 
   /* TODO:
-   *  test config bits and set status bits to prevent methods from sending commands that would generate errors
    *  reduce the sleeps to see which ones are necessary
    *  print out useful info for asyn traces
-   *  make reconfig useful
+   *  make reconfig useful?
    */
 
   epicsThreadSleep(0.1);
@@ -520,6 +521,9 @@ void ANF2Axis::getInfo()
   }
 }
 
+/*
+// reconfig was used during development. It won't be generally useful without effort.
+// It isn't obvious that this is a feature that should exist on-the-fly
 void ANF2Axis::reconfig(epicsInt32 value)
 {
   asynStatus status;
@@ -555,7 +559,7 @@ void ANF2Axis::reconfig(epicsInt32 value)
   epicsThreadSleep(0.05);
   getInfo();
 }
-
+*/
 
 /** Reports on status of the axis
   * \param[in] fp The file pointer on which report information will be written

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -313,6 +313,13 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   }
   //printf("ANF2Axis::ANF2Axis : pasynUserConfWrite_->reason=%d\n", pasynUserConfWrite_->reason);
 
+  /* TODO:
+   *  test config bits and set status bits to prevent methods from sending commands that would generate errors
+   *  reduce the sleeps to see which ones are necessary
+   *  make pasynUserConfWrite_ an output array; create a corresponding controller method to simplify calls
+   *  read encoder position
+   */
+
   epicsThreadSleep(0.1);
 
   // Read data that is likely to be stale

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -315,14 +315,13 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
     //printf("%s:%s: Error, unable to connect pasynUserForceRead_ to Modbus input driver %s\n", pC_->inputDriver_, pC_->functionName, myModbusInputDriver);
     printf("%s: Error, unable to connect pasynUserForceRead_ to Modbus input driver\n", pC_->inputDriver_);	
   }
-  printf("ANF2Axis::ANF2Axis : pasynUserForceRead_->reason=%d\n", pasynUserForceRead_->reason);
+  //printf("ANF2Axis::ANF2Axis : pasynUserForceRead_->reason=%d\n", pasynUserForceRead_->reason);
 
   status = pasynInt32ArraySyncIO->connect(ANF2ConfName, axisNo_*AXIS_REG_OFFSET, &pasynUserConfWrite_, NULL);
   if (status) {
     printf("%s: Error, unable to connect pasynUserConfWrite_ to Modbus input driver\n", ANF2ConfName);	
   }
-  printf("ANF2Axis::ANF2Axis : pasynUserConfWrite_->reason=%d\n", pasynUserConfWrite_->reason);
-  printf("ANF2Axis::ANF2Axis : pasynUserConfWrite_ offset=%d\n", axisNo_*AXIS_REG_OFFSET);
+  //printf("ANF2Axis::ANF2Axis : pasynUserConfWrite_->reason=%d\n", pasynUserConfWrite_->reason);
 
   epicsThreadSleep(0.1);
 
@@ -527,7 +526,7 @@ asynStatus ANF2Axis::move(double position, int relative, double minVelocity, dou
   status = sendAccelAndVelocity(acceleration, maxVelocity);
   
   if (relative) {
-    printf(" ** relative move called\n");
+    //printf(" ** relative move called\n");
 
     distance = NINT(position);
   
@@ -537,10 +536,10 @@ asynStatus ANF2Axis::move(double position, int relative, double minVelocity, dou
   
   } else {
     // absolute
-    printf(" ** absolute move called\n");
+    //printf(" ** absolute move called\n");
 
     distance = NINT(position);
-    printf(" ** distance = %d\n", distance);
+    //printf(" ** distance = %d\n", distance);
   
     // Set position and cmd registers
     motionReg_[1] = NINT(position);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -347,9 +347,6 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32
 
   epicsThreadSleep(0.1);
 
-  // Read data that is likely to be stale
-  //getInfo();
-
   // Clear the command/configuration register (a good thing to do but doesn't appear to be necessary)
   //status = pC_->writeReg32Array(axisNo_, zeroReg_, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
@@ -371,9 +368,6 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32
   // Delay
   epicsThreadSleep(0.05);
 
-  // Read the configuration? Or maybe the command registers?
-  //getInfo();
-  
   // Parse the configuration (mostly for asynReport purposes)
   // MSW
   CaptInput_ = (config & (0x1 << 16)) >> 16;
@@ -409,9 +403,6 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32
   
   // Delay
   //epicsThreadSleep(1.0);
-  
-  // Read the command registers
-  //getInfo();
   
   // Tell the driver the axis has been created
   pC_->axesCreated_ += 1;
@@ -545,19 +536,16 @@ void ANF2Axis::reconfig(epicsInt32 value)
   //confReg[CONFIG_REG_4] = 0x0;
 
   epicsThreadSleep(0.05);
-  getInfo();
 
   // Send the new config
   status = pC_->writeReg32Array(axisNo_, confReg_, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
   epicsThreadSleep(0.05);
-  getInfo();
 
   // Set the position to clear the invalid position error  
   setPosition(value);
 
   epicsThreadSleep(0.05);
-  getInfo();
 }
 */
 
@@ -947,16 +935,12 @@ asynStatus ANF2Axis::poll(bool *moving)
     return asynSuccess;
   }
   
-  //getInfo();
-  
   // Force a read operation
   //printf(" . . . . . Calling pasynInt32SyncIO->write\n");
   //printf("Calling pasynInt32SyncIO->write(pasynUserForceRead_, 1, TIMEOUT), pasynUserForceRead_->reason=%d\n", pasynUserForceRead_->reason);
   status = pasynInt32SyncIO->write(pasynUserForceRead_, 1, DEFAULT_CONTROLLER_TIMEOUT);
   //printf(" . . . . . status = %d\n", status);
   // if status goto end
-
-  //getInfo();
 
   // Read the current motor position
   // 

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -502,17 +502,17 @@ asynStatus ANF2Axis::sendAccelAndVelocity(double acceleration, double velocity)
   registers_[2] = NINT(velocity);
 
   // Send the acceleration
-  // ANF2 acceleration range 1 to 5000 steps/ms/sec
+  // ANF2 acceleration range 1 to 2000 steps/ms/sec
   // Therefore need to limit range received by motor record from 1000 to 5e6 steps/sec/sec
   if (acceleration < 1000) {
     // print message noting that accel has been capped low
     //printf("Acceleration is < 1000: %lf\n", acceleration);
     acceleration = 1000;
   }
-  if (acceleration > 5000000) {
+  if (acceleration > 2000000) {
     // print message noting that accel has been capped high
-    //printf("Acceleration is > 5000: %lf\n", acceleration);
-    acceleration = 5000000;
+    //printf("Acceleration is > 2000: %lf\n", acceleration);
+    acceleration = 2000000;
   }
   // ANF2 acceleration units are steps/millisecond/second, so we divide by 1000 here
   //status = pC_->writeReg16(axisNo_, ACCEL, NINT(acceleration/1000.0), DEFAULT_CONTROLLER_TIMEOUT);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -277,7 +277,9 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config)
     pC_(pC)	
 { 
   int status;
+  
   axisNo_ = axisNo;
+  //this->axisNo_ = axisNo;
 
   //status = pasynInt32SyncIO->connect(myModbusInputDriver, 0, &pasynUserForceRead_, "MODBUS_READ");
   status = pasynInt32SyncIO->connect(pC_->inputDriver_, 0, &pasynUserForceRead_, "MODBUS_READ");
@@ -351,8 +353,10 @@ extern "C" asynStatus ANF2CreateAxis(const char *ANF2Name,  /* specify which con
 void ANF2Axis::report(FILE *fp, int level)
 {
   if (level > 0) {
-    fprintf(fp, "  axis %d\n",
-            axisNo_);
+    fprintf(fp, "  axis %d\n", axisNo_);
+    fprintf(fp, "    this->axisNo_ %i\n", this->axisNo_);
+    fprintf(fp, "    this->config_ %x\n", this->config_);
+    fprintf(fp, "    config_ %x\n", config_);
   }
 
   // Call the base class method
@@ -391,7 +395,7 @@ asynStatus ANF2Axis::move(double position, int relative, double minVelocity, dou
   asynStatus status;
   int distance, move_bit;
   
-  printf(" ** ANF2Axis::move called, relative = %d\n", relative);
+  printf(" ** ANF2Axis::move called, relative = %d, axisNo_ = %i\n", relative, this->axisNo_);
 
   status = sendAccelAndVelocity(acceleration, maxVelocity);
   
@@ -583,10 +587,10 @@ asynStatus ANF2Axis::poll(bool *moving)
   // 
   //readReg32(int reg, epicsInt32 *combo, double timeout)
   status = pC_->readReg32(axisNo_, POS_RD_UPR, &read_val, DEFAULT_CONTROLLER_TIMEOUT);
-  printf("ANF2Axis::poll:  Motor position raw: %d\n", read_val);
+  //printf("ANF2Axis::poll:  Motor position raw: %d\n", read_val);
   position = (double) read_val;
   setDoubleParam(pC_->motorPosition_, position);
-  printf("ANF2Axis::poll:  Motor position: %f\n", position);
+  //printf("ANF2Axis::poll:  Motor position: %f\n", position);
 
   // Read the moving status of this motor
   //
@@ -597,12 +601,12 @@ asynStatus ANF2Axis::poll(bool *moving)
   done = ((read_val & 0x8) >> 3);  // status word 1 bit 3 set to 1 when the motor is not in motion.
   setIntegerParam(pC_->motorStatusDone_, done);
   *moving = done ? false:true;
-  printf("done is %d\n", done);
+  //printf("done is %d\n", done);
   
   // Read the limit status
   //
   status = pC_->readReg16(axisNo_, STATUS_2, &read_val, DEFAULT_CONTROLLER_TIMEOUT);
-  printf("status 2 is 0x%X\n", read_val);  
+  //printf("status 2 is 0x%X\n", read_val);  
   
   limit  = (read_val & 0x1);    // a cw limit has been reached
   setIntegerParam(pC_->motorStatusHighLimit_, limit);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -384,7 +384,7 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32
   CCWInputAS_ = (config & 0x10) >> 4;
   
   // Only allow UEIP to be used if the axis is configured to have a quadrature encoder
-  if (QuadEnc_ != 0x0) {
+  if ((QuadEnc_ != 0x0) || (DiagFbk_ != 0x0)) {
     setIntegerParam(pC_->motorStatusHasEncoder_, 1);
   } else {
     setIntegerParam(pC_->motorStatusHasEncoder_, 0);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -628,20 +628,29 @@ asynStatus ANF2Axis::stop(double acceleration)
 asynStatus ANF2Axis::setPosition(double position)
 {
   asynStatus status;
-  int set_position, set_bit;
+  int set_bit;
+  epicsInt32 set_position;
   //static const char *functionName = "ANF2Axis::setPosition";
 
   //status = writeReg32(SPD_UPR, velo, DEFAULT_CONTROLLER_TIMEOUT);
-  //distance = position *  SOM_OTHER_SCALE_FACTOR;
   set_position = NINT(position);
   
-  status = pC_->writeReg32(axisNo_, POS_WR_UPR, set_position, DEFAULT_CONTROLLER_TIMEOUT);
+  //status = pC_->writeReg32(axisNo_, POS_WR_UPR, set_position, DEFAULT_CONTROLLER_TIMEOUT);
 
   set_bit = 0x200;
-  status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  //status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
 
   set_bit = 0x0;
-  status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  //status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
+
+  registers_[0] = 0x200 << 16;
+  registers_[1] = set_position;
+  registers_[2] = 0x0;
+  registers_[3] = 0x0;
+  registers_[4] = 0x0;
+
+  // Write all the registers atomically
+  status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, registers_, 10, DEFAULT_CONTROLLER_TIMEOUT);
 
   return status;
 }

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -823,6 +823,7 @@ asynStatus ANF2Axis::poll(bool *moving)
   int limit;
   int enabled;
   double position;
+  double encPosition;
   asynStatus status;
   epicsInt32 read_val;  // don't use a pointer here.  The _address_ of read_val should be passed to the read function.
   
@@ -853,6 +854,11 @@ asynStatus ANF2Axis::poll(bool *moving)
   //printf("ANF2Axis::poll:  Motor #%i position: %f\n", axisNo_, position);
 
   //  TODO: read encoder position
+  status = pC_->readReg32(axisNo_, EN_POS_UPR, &read_val, DEFAULT_CONTROLLER_TIMEOUT);
+  //printf("ANF2Axis::poll:  Motor encoder position raw: %d\n", read_val);
+  encPosition = (double) read_val;
+  setDoubleParam(pC_->motorEncoderPosition_, encPosition);
+  //printf("ANF2Axis::poll:  Motor #%i encoder position: %f\n", axisNo_, encPosition);
 
   // Read the moving status of this motor
   //

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -345,6 +345,8 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   
   // set position to 0
   setPosition(0);
+  //setDoubleParam(pC_->motorPosition_, 0.0);
+  //callParamCallbacks();
   
   // Delay
   //epicsThreadSleep(1.0);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -324,10 +324,10 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   printf("ANF2Axis::ANF2Axis : pasynUserConfWrite_->reason=%d\n", pasynUserConfWrite_->reason);
   printf("ANF2Axis::ANF2Axis : pasynUserConfWrite_ offset=%d\n", axisNo_*AXIS_REG_OFFSET);
 
-  epicsThreadSleep(1.0);
+  epicsThreadSleep(0.1);
 
   // Read data that is likely to be stale
-  getInfo();
+  //getInfo();
 
   // Send the configuration (array) 
   // assemble the configuration bits; set the start speed to a non-zero value (100), which is required for the configuration to be accepted
@@ -338,21 +338,19 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, confReg_, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
   // Delay
-  epicsThreadSleep(1.0);
+  epicsThreadSleep(0.05);
 
   // Read the configuration? Or maybe the command registers?
-  getInfo();
+  //getInfo();
   
   // set position to 0
-  //setPosition(0);
-  setPosition(1337);
-  //setPosition(3141);
+  setPosition(0);
   
   // Delay
-  epicsThreadSleep(1.0);
+  //epicsThreadSleep(1.0);
   
   // Read the command registers
-  getInfo();
+  //getInfo();
   
   // Tell the driver the axis has been created
   pC_->axesCreated_ += 1;
@@ -657,6 +655,8 @@ asynStatus ANF2Axis::setPosition(double position)
   zeroRegisters(posReg);
   // Clear the command/configuration register
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, posReg, 5, DEFAULT_CONTROLLER_TIMEOUT);
+
+  epicsThreadSleep(0.05);
 
   //status = writeReg32(SPD_UPR, velo, DEFAULT_CONTROLLER_TIMEOUT);
   set_position = NINT(position);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -311,8 +311,7 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
     pC_(pC)	
 { 
   int status;
-  epicsInt32 configBits[2];
-  
+
   axisNo_ = axisNo;
   //this->axisNo_ = axisNo;
 
@@ -346,16 +345,10 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
  
   // Send the configuration (array) 
   // assemble the configuration bits; set the start speed to a non-zero value (100), which is required for the configuration to be accepted
-  configBits[0] = config;
-  configBits[1] = 0x00000064;
-  
   registers_[0] = config;
   registers_[1] = 0x00000064;
   
   // Does the number of elements refer to the number of 16-bit elements?
-  //status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
-  // Mabye do it this way in the future
-  //status = this->pC_->writeReg32Array(axisNo, CONFIG_MSW, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
   // Write all the registers
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, registers_, 10, DEFAULT_CONTROLLER_TIMEOUT);
 

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -569,12 +569,13 @@ void ANF2Axis::report(FILE *fp, int level)
 
   if (level > 0) {
     fprintf(fp, "Configuration for axis %i:\n", axisNo_);
-    fprintf(fp, "  Base Speed: %i\tHoming Timeout: %i\n", baseSpeed_, homingTimeout_);
-    fprintf(fp, "  Capture Input: %i\tActive State: %i\n", CaptInput_, CaptInputAS_);
-    fprintf(fp, "  External Input: %i\tActive State: %i\n", ExtInput_, ExtInputAS_);
-    fprintf(fp, "  Home Input: %i\tActive State: %i\n", HomeInput_, HomeInputAS_);
-    fprintf(fp, "  CW Input: %i\tActive State: %i\n", CWInput_, CWInputAS_);
-    fprintf(fp, "  CCW Input: %i\tActive State: %i\n", CCWInput_, CCWInputAS_);
+    fprintf(fp, "  Base Speed: %i\n", baseSpeed_);
+    fprintf(fp, "  Homing Timeout: %i\n", homingTimeout_);
+    fprintf(fp, "  Capture Input: %i (Active State: %i)\n", CaptInput_, CaptInputAS_);
+    fprintf(fp, "  External Input: %i (Active State: %i)\n", ExtInput_, ExtInputAS_);
+    fprintf(fp, "  Home Input: %i (Active State: %i)\n", HomeInput_, HomeInputAS_);
+    fprintf(fp, "  CW Input: %i (Active State: %i)\n", CWInput_, CWInputAS_);
+    fprintf(fp, "  CCW Input: %i (Active State: %i)\n", CCWInput_, CCWInputAS_);
     fprintf(fp, "  Backplane Home Proximity Operation: %i\n", BHPO_);
     fprintf(fp, "  Quadrature Encoder: %i\n", QuadEnc_);
     fprintf(fp, "  Diagnostic Feedback: %i\n", DiagFbk_);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -349,6 +349,34 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config)
   // Read the configuration? Or maybe the command registers?
   //getInfo();
   
+  // Parse the configuration (mostly for asynReport purposes)
+  // MSW
+  CaptInput_ = (config & (0x1 << 16)) >> 16;
+  ExtInput_ = (config & (0x2 << 16)) >> 17;
+  HomeInput_ = (config & (0x4 << 16)) >> 18;
+  CWInput_ = (config & (0x18 << 16)) >> 19;
+  CCWInput_ = (config & (0x60 << 16)) >> 21;
+  BHPO_ = (config & (0x80 << 16)) >> 23;
+  QuadEnc_ = (config & (0x100 << 16)) >> 24;
+  DiagFbk_ = (config & (0x200 << 16)) >> 25;
+  OutPulse_ = (config & (0x400 << 16)) >> 26;
+  HomeOp_ = (config & (0x800 << 16)) >> 27; 
+  CardAxis_ = (config & (0x4000 << 16)) >> 30;
+  OpMode_ = (config & (0x8000 << 16)) >> 31;
+  // LSW
+  CaptInputAS_ = config & 0x1;
+  ExtInputAS_ = (config & 0x2) >> 1;
+  HomeInputAS_ = (config & 0x4) >> 2;
+  CWInputAS_ = (config & 0x8) >> 3;
+  CCWInputAS_ = (config & 0x10) >> 4;
+  
+  // Only allow UEIP to be used if the axis is configured to have a quadrature encoder
+  if (QuadEnc_ != 0x0) {
+    setIntegerParam(pC_->motorStatusHasEncoder_, 1);
+  } else {
+    setIntegerParam(pC_->motorStatusHasEncoder_, 0);
+  }
+  
   // set position to 0 to clear the "position invalid" status that results from configuring the axis
   setPosition(0);
   // Tell asynMotor device support the position is zero so that autosave will restore the saved position (doesn't appear to be necessary)
@@ -425,6 +453,20 @@ void ANF2Axis::getInfo()
   
   // For a read (not sure why this is necessary)
   status = pasynInt32SyncIO->write(pasynUserForceRead_, 1, DEFAULT_CONTROLLER_TIMEOUT);
+
+  printf("Configuration for axis %i:\n", axisNo_);
+  printf("  Capture Input: %i\tActive State: %i\n", CaptInput_, CaptInputAS_);
+  printf("  External Input: %i\tActive State: %i\n", ExtInput_, ExtInputAS_);
+  printf("  Home Input: %i\tActive State: %i\n", HomeInput_, HomeInputAS_);
+  printf("  CW Input: %i\tActive State: %i\n", CWInput_, CWInputAS_);
+  printf("  CCW Input: %i\tActive State: %i\n", CCWInput_, CCWInputAS_);
+  printf("  Backplane Home Proximity Operation: %i\n", BHPO_);
+  printf("  Quadrature Encoder: %i\n", QuadEnc_);
+  printf("  Diagnostic Feedback: %i\n", DiagFbk_);
+  printf("  Output Pulse Type: %i\n", OutPulse_);
+  printf("  Home Operation: %i\n", HomeOp_);
+  printf("  Card Axis: %i\n", CardAxis_);
+  printf("  Operation Mode for Axis: %i\n", OpMode_);
 
   printf("Registers for axis %i:\n", axisNo_);
 

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -649,25 +649,13 @@ asynStatus ANF2Axis::setPosition(double position)
   epicsInt32 posReg[5];
   //static const char *functionName = "ANF2Axis::setPosition";
   
-  //set_bit = 0x0;
-  //status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
-
   zeroRegisters(posReg);
   // Clear the command/configuration register
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, posReg, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
   epicsThreadSleep(0.05);
 
-  //status = writeReg32(SPD_UPR, velo, DEFAULT_CONTROLLER_TIMEOUT);
   set_position = NINT(position);
-  
-  //status = pC_->writeReg32(axisNo_, POS_WR_UPR, set_position, DEFAULT_CONTROLLER_TIMEOUT);
-
-  set_bit = 0x200;
-  //status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
-
-  //set_bit = 0x0;
-  //status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
 
   posReg[0] = 0x200 << 16;
   posReg[1] = set_position;
@@ -677,6 +665,13 @@ asynStatus ANF2Axis::setPosition(double position)
 
   // Write all the registers atomically
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, posReg, 5, DEFAULT_CONTROLLER_TIMEOUT);
+
+  //epicsThreadSleep(0.05);
+
+  // The ANG1 driver does this; do we need to?
+  //zeroRegisters(posReg);
+  // Clear the command/configuration register
+  //status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, posReg, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
   return status;
 }

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -329,6 +329,12 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   // Read data that is likely to be stale
   //getInfo();
 
+  // Clear the command/configuration register
+  //status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, zeroReg_, 5, DEFAULT_CONTROLLER_TIMEOUT);
+
+  // Delay
+  //epicsThreadSleep(0.05);
+
   // These registers will always have the last config that was sent to the controller
   zeroRegisters(confReg_);
 
@@ -359,6 +365,8 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   
   // Tell the driver the axis has been created
   pC_->axesCreated_ += 1;
+  
+  //epicsThreadSleep(1.0);
 }
 
 /*
@@ -654,10 +662,12 @@ asynStatus ANF2Axis::setPosition(double position)
   epicsInt32 posReg[5];
   //static const char *functionName = "ANF2Axis::setPosition";
   
+  printf("setPosition(%lf) for axisNo_=%i\n", position, axisNo_);
+  
   // Clear the command/configuration register
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, zeroReg_, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
-  epicsThreadSleep(0.05);
+  epicsThreadSleep(0.1);
 
   set_position = NINT(position);
 
@@ -671,7 +681,7 @@ asynStatus ANF2Axis::setPosition(double position)
   // Write all the registers atomically
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, posReg, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
-  //epicsThreadSleep(0.05);
+  epicsThreadSleep(0.20);
 
   // The ANG1 driver does this; do we need to?
   // Clear the command/configuration register

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -155,19 +155,31 @@ void ANF2Controller::doStartPoller(double movingPollPeriod, double idlePollPerio
 void ANF2Controller::report(FILE *fp, int level)
 {
   int i, j;
+  ANF2Axis *pAxis;
   
-  fprintf(fp, "ANF2 motor driver %s, numAxes=%d, moving poll period=%f, idle poll period=%f\n", 
-    this->portName, numAxes_, movingPollPeriod_, idlePollPeriod_);
-  fprintf(fp, "    axesCreated=%i\n", axesCreated_);
+  fprintf(fp, "====================================\n");
+  fprintf(fp, "ANF2 motor driver:\n");
+  fprintf(fp, "    asyn port: %s\n", this->portName);
+  fprintf(fp, "    num axes: %i\n", numAxes_);
+  fprintf(fp, "    axes created: %i\n", axesCreated_);
+  fprintf(fp, "    moving poll period: %lf\n", movingPollPeriod_);
+  fprintf(fp, "    idle poll period: %lf\n", idlePollPeriod_);
   
   for (j=0; j<numAxes_; j++) {
-  fprintf(fp, "  axis #%i\n", j);
-    for (i=0; i<MAX_INPUT_REGS; i++) {
+    fprintf(fp, "========\n");
+    fprintf(fp, "AXIS #%i\n", j);
+    fprintf(fp, "========\n");
+  
+    pAxis = getAxis(j);
+    pAxis->getInfo();
+  
+    /*for (i=0; i<MAX_INPUT_REGS; i++) {
        fprintf(fp, "    reg %i, pasynUserInReg_[%i][%i]=0x%x\n", i, j, i, pasynUserInReg_[j][i]);
-     }
+    }*/
   }
   // Call the base class method
   asynMotorController::report(fp, level);
+  fprintf(fp, "====================================\n");
 }
 
 /** Returns a pointer to an ANF2Axis object.
@@ -426,12 +438,13 @@ void ANF2Axis::getInfo()
   // For a read (not sure why this is necessary)
   status = pasynInt32SyncIO->write(pasynUserForceRead_, 1, DEFAULT_CONTROLLER_TIMEOUT);
 
-  printf("Info for axis %i\n", axisNo_);
+  printf("Registers for axis %i:\n", axisNo_);
 
   for( i=0; i<MAX_INPUT_REGS; i++)
   {
     status = pC_->readReg16(axisNo_, i, &read_val, DEFAULT_CONTROLLER_TIMEOUT);
-    printf("  status=%d, register=%i, val=0x%x\n", status, i, read_val);
+    //printf("  status=%d, register=%i, val=0x%x\n", status, i, read_val);
+    printf("  register=%i, val=0x%x\n", i, read_val);
   }
 }
 

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -362,7 +362,7 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config)
   OutPulse_ = (config & (0x400 << 16)) >> 26;
   HomeOp_ = (config & (0x800 << 16)) >> 27; 
   CardAxis_ = (config & (0x4000 << 16)) >> 30;
-  OpMode_ = (config & (0x8000 << 16)) >> 31;
+  OpMode_ = (epicsUInt32)(config & (0x8000 << 16)) >> 31;
   // LSW
   CaptInputAS_ = config & 0x1;
   ExtInputAS_ = (config & 0x2) >> 1;

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -503,7 +503,7 @@ asynStatus ANF2Axis::move(double position, int relative, double minVelocity, dou
     //status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
     
     move_bit = 0x0;
-    //status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
     
     move_bit = 0x2;
     //status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
@@ -521,7 +521,7 @@ asynStatus ANF2Axis::move(double position, int relative, double minVelocity, dou
     //status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
     
     move_bit = 0x0;
-    //status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
     
     move_bit = 0x1;
     //status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);	

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -32,12 +32,11 @@ static const char *driverName = "ANF2MotorDriver";
   * \param[in] portName          The name of the asyn port that will be created for this driver
   * \param[in] ANF2InPortName    The name of the drvAsynSerialPort that was created previously to connect to the ANF2 controller 
   * \param[in] ANF2OutPortName   The name of the drvAsynSerialPort that was created previously to connect to the ANF2 controller 
-  * \param[in] numModules        The number of modules on the controller stack 
-  * \param[in] axesPerModule     The number of axes per module (ANF1=1, ANF2=2)
+  * \param[in] numAxes           The number of axes on the controller stack 
   */
 ANF2Controller::ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName,  
-                                 int numModules, int axesPerModule)
-  :  asynMotorController(portName, (numModules*axesPerModule), NUM_ANF2_PARAMS, 
+                                 int numAxes)
+  :  asynMotorController(portName, numAxes, NUM_ANF2_PARAMS, 
                          asynInt32ArrayMask, // One additional interface beyond those in base class
                          asynInt32ArrayMask, // One additional callback interface beyond those in base class
                          ASYN_CANBLOCK | ASYN_MULTIDEVICE, 
@@ -58,9 +57,7 @@ ANF2Controller::ANF2Controller(const char *portName, const char *ANF2InPortName,
   createParam(ANF2GetInfoString,         asynParamInt32,       &ANF2GetInfo_);
   //createParam(ANF2ReconfigString,        asynParamInt32,       &ANF2Reconfig_);
 
-  numModules_ = numModules;
-  axesPerModule_ = axesPerModule;
-  numAxes_ = numModules * axesPerModule;
+  numAxes_ = numAxes;
   
   for (j=0; j<numAxes_; j++) {
     /* Connect to ANF2 controller */
@@ -86,26 +83,16 @@ ANF2Controller::ANF2Controller(const char *portName, const char *ANF2InPortName,
   * \param[in] portName          The name of the asyn port that will be created for this driver
   * \param[in] ANF2InPortName    The name of the drvAsynIPPPort that was created previously to connect to the ANF2 controller 
   * \param[in] ANF2OutPortName   The name of the drvAsynIPPPort that was created previously to connect to the ANF2 controller 
-  * \param[in] numModules        The number of modules on the controller stack 
-  * \param[in] axesPerModule     The number of axes per module (ANF1=1, ANF2=2)
+  * \param[in] numAxes           The number of axes on the controller stack 
   */
-extern "C" int ANF2CreateController(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, 
-                                      int numModules, int axesPerModule)
+extern "C" int ANF2CreateController(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numAxes)
 {
   // Enforce max values
-  if (numModules > MAX_MODULES) {
-    numModules = MAX_MODULES;
-  }
-  if (axesPerModule > MAX_AXES_PER_MODULE) {
-    axesPerModule = MAX_AXES_PER_MODULE;
+  if (numAxes > MAX_AXES) {
+    numAxes = MAX_AXES;
   }
 
-  /*
-  ANF2Controller *pANF2Controller
-    = new ANF2Controller(portName, ANF2InPortName, ANF2OutPortName, numModules, axesPerModule);
-  pANF2Controller = NULL;
-  */
-  new ANF2Controller(portName, ANF2InPortName, ANF2OutPortName, numModules, axesPerModule);
+  new ANF2Controller(portName, ANF2InPortName, ANF2OutPortName, numAxes);
   return(asynSuccess);
 }
 
@@ -1047,17 +1034,15 @@ asynStatus ANF2Axis::poll(bool *moving)
 static const iocshArg ANF2CreateControllerArg0 = {"Port name", iocshArgString};
 static const iocshArg ANF2CreateControllerArg1 = {"ANF2 In port name", iocshArgString};
 static const iocshArg ANF2CreateControllerArg2 = {"ANF2 Out port name", iocshArgString};
-static const iocshArg ANF2CreateControllerArg3 = {"Number of modules", iocshArgInt};
-static const iocshArg ANF2CreateControllerArg4 = {"Axes per module", iocshArgInt};
+static const iocshArg ANF2CreateControllerArg3 = {"Number of axes", iocshArgInt};
 static const iocshArg * const ANF2CreateControllerArgs[] = {&ANF2CreateControllerArg0,
                                                              &ANF2CreateControllerArg1,
                                                              &ANF2CreateControllerArg2,
-                                                             &ANF2CreateControllerArg3,
-                                                             &ANF2CreateControllerArg4};
-static const iocshFuncDef ANF2CreateControllerDef = {"ANF2CreateController", 5, ANF2CreateControllerArgs};
+                                                             &ANF2CreateControllerArg3};
+static const iocshFuncDef ANF2CreateControllerDef = {"ANF2CreateController", 4, ANF2CreateControllerArgs};
 static void ANF2CreateControllerCallFunc(const iocshArgBuf *args)
 {
-  ANF2CreateController(args[0].sval, args[1].sval, args[2].sval, args[3].ival, args[4].ival);
+  ANF2CreateController(args[0].sval, args[1].sval, args[2].sval, args[3].ival);
 }
 
 /* ANF2StartPoller */

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -1,0 +1,690 @@
+/*
+FILENAME... ANF2Driver.cpp
+USAGE...    Motor record driver support for the AMCI ANF2 stepper motor controller over Modbus/TCP.
+
+Kevin Peterson
+
+Based on the AMCI ANG1 Model 3 device driver written by Kurt Goetze
+
+*/
+
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+#include <errno.h>
+
+#include <iocsh.h>
+#include <epicsThread.h>
+#include <epicsString.h>
+
+#include <asynInt32SyncIO.h>
+
+#include "ANF2Driver.h"
+#include <epicsExport.h>
+
+#define NINT(f) (int)((f)>0 ? (f)+0.5 : (f)-0.5)
+
+static const char *driverName = "ANF2MotorDriver";
+
+/** Constructor, Creates a new ANF2Controller object.
+  * \param[in] portName          The name of the asyn port that will be created for this driver
+  * \param[in] ANF2InPortName    The name of the drvAsynSerialPort that was created previously to connect to the ANF2 controller 
+  * \param[in] ANF2OutPortName   The name of the drvAsynSerialPort that was created previously to connect to the ANF2 controller 
+  * \param[in] numAxes           The number of axes that this controller supports 
+  * \param[in] movingPollPeriod  The time between polls when any axis is moving 
+  * \param[in] idlePollPeriod    The time between polls when no axis is moving 
+  */
+ANF2Controller::ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numAxes, 
+                                 double movingPollPeriod, double idlePollPeriod)
+  :  asynMotorController(portName, numAxes, NUM_ANF2_PARAMS, 
+                         0, // No additional interfaces beyond those in base class
+                         0, // No additional callback interfaces beyond those in base class
+                         ASYN_CANBLOCK | ASYN_MULTIDEVICE, 
+                         1, // autoconnect
+                         0, 0)  // Default priority and stack size
+{
+  int i, j;
+  asynStatus status = asynSuccess;
+  static const char *functionName = "ANF2Controller::ANF2Controller";
+  
+  inputDriver_ = epicsStrDup(ANF2InPortName);    // Set this before calls to create Axis objects
+  
+  // Create controller-specific parameters
+  createParam(ANF2JerkString,         asynParamInt32,       &ANF2Jerk_);
+  
+  if (numAxes > MAX_AXES) {
+    numAxes = MAX_AXES;
+  }
+  
+  for (j=0; j<numAxes; j++) {
+    /* Connect to ANF2 controller */
+    for (i=0; i<MAX_INPUT_REGS; i++) {
+      status = pasynInt32SyncIO->connect(ANF2InPortName, i, &pasynUserInReg_[j][i], NULL);
+    }
+    for (i=0; i<MAX_OUTPUT_REGS; i++) {
+      status = pasynInt32SyncIO->connect(ANF2OutPortName, i, &pasynUserOutReg_[j][i], NULL);
+    }
+  }
+  if (status) {
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
+      "%s: cannot connect to ANF2 controller\n",
+      functionName);
+  }
+
+  /* Create the poller thread for this controller (do 2 forced-fast polls)
+   * NOTE: at this point the axis objects don't yet exist, but the poller tolerates this <- KMP: how does it tolerate this? */
+  startPoller(movingPollPeriod, idlePollPeriod, 2);
+}
+
+
+/** Creates a new ANF2Controller object.
+  * Configuration command, called directly or from iocsh
+  * \param[in] portName          The name of the asyn port that will be created for this driver
+  * \param[in] ANF2InPortName    The name of the drvAsynIPPPort that was created previously to connect to the ANF2 controller 
+  * \param[in] ANF2OutPortName   The name of the drvAsynIPPPort that was created previously to connect to the ANF2 controller 
+  * \param[in] numAxes           The number of axes that this controller supports 
+  * \param[in] movingPollPeriod  The time in ms between polls when any axis is moving
+  * \param[in] idlePollPeriod    The time in ms between polls when no axis is moving 
+  */
+extern "C" int ANF2CreateController(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numAxes, 
+                                   int movingPollPeriod, int idlePollPeriod)
+{
+  /*
+  ANF2Controller *pANF2Controller
+    = new ANF2Controller(portName, ANF2InPortName, ANF2OutPortName, numAxes, movingPollPeriod/1000., idlePollPeriod/1000.);
+  pANF2Controller = NULL;
+  */
+  new ANF2Controller(portName, ANF2InPortName, ANF2OutPortName, numAxes, movingPollPeriod/1000., idlePollPeriod/1000.);
+  return(asynSuccess);
+}
+
+/** Reports on status of the driver
+  * \param[in] fp The file pointer on which report information will be written
+  * \param[in] level The level of report detail desired
+  *
+  * If details > 0 then information is printed about each axis.
+  * After printing controller-specific information it calls asynMotorController::report()
+  */
+void ANF2Controller::report(FILE *fp, int level)
+{
+  fprintf(fp, "ANF2 motor driver %s, numAxes=%d, moving poll period=%f, idle poll period=%f\n", 
+    this->portName, numAxes_, movingPollPeriod_, idlePollPeriod_);
+
+  // Call the base class method
+  asynMotorController::report(fp, level);
+}
+
+/** Returns a pointer to an ANF2Axis object.
+  * Returns NULL if the axis number encoded in pasynUser is invalid.
+  * \param[in] pasynUser asynUser structure that encodes the axis index number. */
+ANF2Axis* ANF2Controller::getAxis(asynUser *pasynUser)
+{
+//  ?  return static_cast<ANF2Axis*>(asynMotorController::getAxis(pANF2Axis methodsasynUser));
+  return static_cast<ANF2Axis*>(asynMotorController::getAxis(pasynUser));
+}
+
+/** Returns a pointer to an ANF2Axis object.
+  * Returns NULL if the axis number encoded in pasynUser is invalid.
+  * \param[in] No Axis index number. */
+ANF2Axis* ANF2Controller::getAxis(int axisNo)
+{
+  return static_cast<ANF2Axis*>(asynMotorController::getAxis(axisNo));
+}
+
+/** Called when asyn clients call pasynInt32->write().
+  * Extracts the function and axis number from pasynUser.
+  * Sets the value in the parameter library (?)
+  *
+  * If the function is ANF2Jerk_ it sets the jerk value in the controller.
+  * Calls any registered callbacks for this pasynUser->reason and address.
+  *
+  * For all other functions it calls asynMotorController::writeInt32.
+  * \param[in] pasynUser asynUser structure that encodes the reason and address.
+  * \param[in] value Value to write. */
+asynStatus ANF2Controller::writeInt32(asynUser *pasynUser, epicsInt32 value)
+{
+  int function = pasynUser->reason;
+  asynStatus status = asynSuccess;
+  ANF2Axis *pAxis = getAxis(pasynUser);
+  static const char *functionName = "writeInt32";
+  
+  /* Set the parameter and readback in the parameter library. */
+  status = setIntegerParam(pAxis->axisNo_, function, value);
+  
+  // The ANF controller doesn't have a jerk variable
+  // Could probably just not overload writeInt32 at all
+  /*
+  if (function == ANF2Jerk_)
+  {
+    // Jerk in units steps/sec/sec/sec (0 - 5000)
+    printf("Jerk = %d\n", value);
+	status = writeReg16(JERK, value, DEFAULT_CONTROLLER_TIMEOUT);
+
+//    sprintf(outString_, "%s JOG JRK %f", pAxis->axisName_, value);
+//    status = writeController();
+    
+  } else {
+  // Call base class method
+    status = asynMotorController::writeInt32(pasynUser, value);
+  }
+  */
+  // Call base class method
+  status = asynMotorController::writeInt32(pasynUser, value);
+  
+  /* Do callbacks so higher layers see any changes */
+  pAxis->callParamCallbacks();
+  if (status)
+    asynPrint(pasynUser, ASYN_TRACE_ERROR, 
+        "%s:%s: error, status=%d function=%d, value=%d\n", 
+        driverName, functionName, status, function, value); 
+  else
+    asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
+        "%s:%s: function=%d, value=%d\n", 
+        driverName, functionName, function, value); 
+  return status;
+}
+
+asynStatus ANF2Controller::writeReg16(int axisNo, int axisReg, int output, double timeout)
+{
+  asynStatus status;
+
+  //printf("writeReg16: writing %d to register %d\n", output, axisReg);
+  asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER,"writeReg16: writing %d to register %d\n", output, axisReg);  
+  status = pasynInt32SyncIO->write(pasynUserOutReg_[axisNo][axisReg], output, timeout);
+  epicsThreadSleep(0.01);
+                                  
+  return status ;
+}
+
+asynStatus ANF2Controller::writeReg32(int axisNo, int axisReg, int output, double timeout)
+{
+//.. break 32-bit integer into 2 pieces
+//.. write the pieces into ANF2 registers
+
+  asynStatus status;
+  float fnum;
+  int lower,upper;
+
+  fnum = (output / 1000.0);
+  upper = (int)fnum;
+  fnum = fnum - upper;
+  fnum = NINT(fnum * 1000);
+  lower = (int)fnum;
+
+  //  writeReg16(piece1 ie MSW ...
+  status = writeReg16(axisNo, axisReg, upper, DEFAULT_CONTROLLER_TIMEOUT);
+  
+  //  writeReg16(piece2 ie LSW ...
+  axisReg++;
+  status = writeReg16(axisNo, axisReg, lower, DEFAULT_CONTROLLER_TIMEOUT);
+
+  return status ;
+}
+
+asynStatus ANF2Controller::readReg16(int axisNo, int axisReg, epicsInt32 *input, double timeout)
+{
+  asynStatus status;
+  
+  //printf("axisReg = %d\n", axisReg);
+  asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER,"readReg16 reg = %d\n", axisReg);
+  status = pasynInt32SyncIO->read(pasynUserInReg_[axisNo][axisReg], input, timeout);
+                                  
+  return status ;
+}
+
+asynStatus ANF2Controller::readReg32(int axisNo, int axisReg, epicsInt32 *combo, double timeout)
+{
+//.. read 2 16-bit words from ANF2 registers
+//.. assemble 2 16-bit pieces into 1 32-bit integer
+
+  asynStatus status;
+//  float fnum;
+  epicsInt32 lowerWord32, upperWord32;        // only have pasynInt32SyncIO, not pasynInt16SyncIO ,
+  epicsInt16 lowerWord16, upperWord16;        // so we need to get 32-bits and cast to 16-bit integer
+  
+  //printf("calling readReg16\n");
+  status = readReg16(axisNo, axisReg, &upperWord32, timeout);    //get Upper Word
+  upperWord16 = (epicsInt16)upperWord32;
+  //printf("upperWord16: %d\n", upperWord16);
+  asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER,"readReg32 upperWord16: %d\n", upperWord16);
+
+  // if status != 1 :
+  axisReg++;
+  status = readReg16(axisNo, axisReg, &lowerWord32, timeout);  //get Lower Word
+  lowerWord16 = (epicsInt16)lowerWord32;
+  //printf("lowerWord16: %d\n", lowerWord16);
+  asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER,"readReg32 lowerWord16: %d\n", lowerWord16);
+  
+  *combo = NINT((upperWord16 * 1000) + lowerWord16);
+  
+  return status ;
+}
+
+
+// ANF2Axis methods Here
+// These are the ANF2Axis methods
+
+/** Creates a new ANF2Axis object.
+  * \param[in] pC Pointer to the ANF2Controller to which this axis belongs. 
+  * \param[in] axisNo Index number of this axis, range 0 to pC->numAxes_-1.
+  * 
+  * Initializes register numbers, etc.
+  */
+ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config)
+  : asynMotorAxis(pC, axisNo),
+    pC_(pC)	
+{ 
+  int status;
+  axisNo_ = axisNo;
+
+  //status = pasynInt32SyncIO->connect(myModbusInputDriver, 0, &pasynUserForceRead_, "MODBUS_READ");
+  status = pasynInt32SyncIO->connect(pC_->inputDriver_, 0, &pasynUserForceRead_, "MODBUS_READ");
+  if (status) {
+    //printf("%s:%s: Error, unable to connect pasynUserForceRead_ to Modbus input driver %s\n", pC_->inputDriver_, pC_->functionName, myModbusInputDriver);
+    printf("%s: Error, unable to connect pasynUserForceRead_ to Modbus input driver\n", pC_->inputDriver_);	
+  }
+  printf("ANF2Axis::ANF2Axis : pasynUserForceRead_->reason=%d\n", pasynUserForceRead_->reason);
+
+  // Send the configuration
+  status = pC_->writeReg32(axisNo_, CONFIG_MSW, config, DEFAULT_CONTROLLER_TIMEOUT);
+  
+  // set position to 0
+  setPosition(0);
+}
+
+/*
+ Configuration Bits:
+ 0x1  - Caputure Input (0 = Disabled, 1 = Enabled)
+ 0x2  - External Input (0 = Disabled, 1 = Enabled)
+ 0x4  - Home Input (0 = Disabled, 1 = Enabled)
+ 0x8  - 
+
+
+
+
+
+
+
+ */
+
+extern "C" asynStatus ANF2CreateAxis(const char *ANF2Name,  /* specify which controller by port name */
+                         int axis,                         /* axis number 0-1 */
+                         const char *hexConfig)            /* desired configuration in hex */
+{
+  ANF2Controller *pC;
+  epicsInt32 config;
+  static const char *functionName = "ANF2CreateAxis";
+
+  pC = (ANF2Controller*) findAsynPortDriver(ANF2Name);
+  if (!pC) {
+    printf("%s:%s: Error port %s not found\n",
+           driverName, functionName, ANF2Name);
+    return asynError;
+  }
+
+  errno = 0;
+  config = strtoul(hexConfig, NULL, 16);
+  if (errno != 0) {
+    printf("%s:%s: Error invalid config=%s\n",
+           driverName, functionName, hexConfig);
+    return asynError;
+  } else {
+    printf("%s:%s: Config=>%s=%x\n",
+           driverName, functionName, hexConfig, config);
+  }
+  
+  pC->lock();
+  new ANF2Axis(pC, axis, config);
+  pC->unlock();
+  return asynSuccess;
+}
+
+
+/** Reports on status of the axis
+  * \param[in] fp The file pointer on which report information will be written
+  * \param[in] level The level of report detail desired
+  *
+  * After printing device-specific information calls asynMotorAxis::report()
+  */
+void ANF2Axis::report(FILE *fp, int level)
+{
+  if (level > 0) {
+    fprintf(fp, "  axis %d\n",
+            axisNo_);
+  }
+
+  // Call the base class method
+  asynMotorAxis::report(fp, level);
+}
+
+// SET VEL & ACCEL
+asynStatus ANF2Axis::sendAccelAndVelocity(double acceleration, double velocity) 
+{
+  asynStatus status;
+  // static const char *functionName = "ANF2::sendAccelAndVelocity";
+
+  // Send the velocity
+  status = pC_->writeReg32(axisNo_, SPD_UPR, NINT(velocity), DEFAULT_CONTROLLER_TIMEOUT);
+
+  // Send the acceleration
+  // ANF2 acceleration range 1 to 5000 steps/ms/sec
+  // Therefore need to limit range received by motor record from 1000 to 5e6 steps/sec/sec
+  if (acceleration < 1000) {
+    // print message noting that accel has been capped low
+    acceleration = 1000;
+  }
+  if (acceleration > 5000000) {
+    // print message noting that accel has been capped high
+    acceleration = 5000000;
+  }
+  // ANF2 acceleration units are steps/millisecond/second, so we divide by 1000 here
+  status = pC_->writeReg16(axisNo_, ACCEL, NINT(acceleration/1000.0), DEFAULT_CONTROLLER_TIMEOUT);
+  status = pC_->writeReg16(axisNo_, DECEL, NINT(acceleration/1000.0), DEFAULT_CONTROLLER_TIMEOUT);
+  return status;
+}
+
+// MOVE
+asynStatus ANF2Axis::move(double position, int relative, double minVelocity, double maxVelocity, double acceleration)
+{
+  asynStatus status;
+  int distance, move_bit;
+  
+  printf(" ** ANF2Axis::move called, relative = %d\n", relative);
+
+  status = sendAccelAndVelocity(acceleration, maxVelocity);
+  
+  if (relative) {
+    printf(" ** relative move called\n");
+    //status = pC_->writeReg32(axisNo_, SPD_UPR, velo, DEFAULT_CONTROLLER_TIMEOUT);
+	//distance = position *  SOM_OTHER_SCALE_FACTOR;
+	distance = NINT(position);
+    status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x2;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  } else {
+    // absolute
+    printf(" ** absolute move called\n");
+    //status = pC_->writeReg32(axisNo_, SPD_UPR, velo, DEFAULT_CONTROLLER_TIMEOUT);
+	//distance = position *  SOM_OTHER_SCALE_FACTOR;
+	distance = NINT(position);
+	printf(" ** distance = %d\n", distance);
+    status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x1;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);	
+  }
+  // Delay the first status read, give the controller some time to return moving status
+  epicsThreadSleep(0.05);
+  return status;
+}
+
+// HOME (needs work)
+asynStatus ANF2Axis::home(double minVelocity, double maxVelocity, double acceleration, int forwards)
+{
+  asynStatus status;
+  int home_bit;
+  // static const char *functionName = "ANF2Axis::home";
+
+  //status = sendAccelAndVelocity(acceleration, maxVelocity);
+
+  if (forwards) {
+    printf(" ** HOMING FORWARDS **\n");
+    home_bit = 0x20;
+	status = pC_->writeReg16(axisNo_, CMD_MSW, home_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  } else {
+    home_bit = 0x40;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, home_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  }
+  return status;
+}
+
+// JOG
+asynStatus ANF2Axis::moveVelocity(double minVelocity, double maxVelocity, double acceleration)
+{
+  asynStatus status;
+  int velo, distance, move_bit;
+  static const char *functionName = "ANF2Axis::moveVelocity";
+
+  asynPrint(pasynUser_, ASYN_TRACE_FLOW,
+    "%s: minVelocity=%f, maxVelocity=%f, acceleration=%f\n",
+    functionName, minVelocity, maxVelocity, acceleration);
+
+  velo = NINT(fabs(maxVelocity));
+    
+  status = sendAccelAndVelocity(acceleration, velo);
+
+  /* ANF2 does not have jog command. Move 1 million steps */
+  if (maxVelocity > 0.) {
+    /* This is a positive move in ANF2 coordinates */
+	//printf(" ** relative move (JOG pos) called\n");
+	distance = 1000000;
+    status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x2;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  } else {
+    /* This is a negative move in ANF2 coordinates */
+    //printf(" ** relative move (JOG neg) called\n");
+	distance = -1000000;
+    status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+	move_bit = 0x2;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  }
+  // Delay the first status read, give the controller some time to return moving status
+  epicsThreadSleep(0.05);
+  return status;
+}
+
+
+// STOP
+asynStatus ANF2Axis::stop(double acceleration)
+{
+  asynStatus status;
+  int stop_bit;
+  //static const char *functionName = "ANF2Axis::stop";
+  
+  printf("\n  STOP \n\n");
+  
+  stop_bit = 0x0;
+  status = pC_->writeReg16(axisNo_, CMD_MSW, stop_bit, DEFAULT_CONTROLLER_TIMEOUT);
+
+//  stop_bit = 0x10;      Immediate stop
+  stop_bit = 0x4;      // Hold move
+  status = pC_->writeReg16(axisNo_, CMD_MSW, stop_bit, DEFAULT_CONTROLLER_TIMEOUT);
+
+  return status;
+}
+
+// SET
+asynStatus ANF2Axis::setPosition(double position)
+{
+  asynStatus status;
+  int set_position, set_bit;
+  //static const char *functionName = "ANF2Axis::setPosition";
+
+  //status = writeReg32(SPD_UPR, velo, DEFAULT_CONTROLLER_TIMEOUT);
+  //distance = position *  SOM_OTHER_SCALE_FACTOR;
+  set_position = NINT(position);
+  
+  status = pC_->writeReg32(axisNo_, POS_WR_UPR, set_position, DEFAULT_CONTROLLER_TIMEOUT);
+
+  set_bit = 0x200;
+  status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
+
+  set_bit = 0x0;
+  status = pC_->writeReg16(axisNo_, CMD_MSW, set_bit, DEFAULT_CONTROLLER_TIMEOUT);
+
+  return status;
+}
+
+// ENABLE TORQUE
+asynStatus ANF2Axis::setClosedLoop(bool closedLoop)
+{
+  asynStatus status;
+  int enable  = 0x8000;
+  int disable = 0x0000;
+  int cmd;
+  
+  printf(" ** setClosedLoop called \n");
+  if (closedLoop) {
+    printf("setting enable %X\n", enable);
+	// Let's reset errors first
+	cmd = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, cmd, DEFAULT_CONTROLLER_TIMEOUT);
+
+	cmd = 0x400;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, cmd, DEFAULT_CONTROLLER_TIMEOUT);	
+
+	cmd = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, cmd, DEFAULT_CONTROLLER_TIMEOUT);	
+    status = pC_->writeReg16(axisNo_, CMD_LSW, enable, DEFAULT_CONTROLLER_TIMEOUT);
+	setIntegerParam(pC_->motorStatusPowerOn_, 1);
+	
+  } else {
+    printf("setting disable %X\n", disable);
+    status = pC_->writeReg16(axisNo_, CMD_LSW, disable, DEFAULT_CONTROLLER_TIMEOUT);
+    setIntegerParam(pC_->motorStatusPowerOn_, 0);
+  }
+
+  return status;
+}
+
+// POLL
+/** Polls the axis.
+  * This function reads motor position, limit status, home status, and moving status
+  * It calls setIntegerParam() and setDoubleParam() for each item that it polls,
+  * and then calls callParamCallbacks() at the end.
+  * \param[out] moving A flag that is set indicating that the axis is moving (true) or done (false). */
+asynStatus ANF2Axis::poll(bool *moving)
+{ 
+  int done;
+  int limit;
+  int enabled;
+  double position;
+  asynStatus status;
+  epicsInt32 read_val;  // don't use a pointer here.  The _address_ of read_val should be passed to the read function.
+  
+  // Force a read operation
+  //printf(" . . . . . Calling pasynInt32SyncIO->write\n");
+  //printf("Calling pasynInt32SyncIO->write(pasynUserForceRead_, 1, TIMEOUT), pasynUserForceRead_->reason=%d\n", pasynUserForceRead_->reason);
+  status = pasynInt32SyncIO->write(pasynUserForceRead_, 1, DEFAULT_CONTROLLER_TIMEOUT);
+  //printf(" . . . . . status = %d\n", status);
+  // if status goto end
+
+  // Read the current motor position
+  // 
+  //readReg32(int reg, epicsInt32 *combo, double timeout)
+  status = pC_->readReg32(axisNo_, POS_RD_UPR, &read_val, DEFAULT_CONTROLLER_TIMEOUT);
+  printf("ANF2Axis::poll:  Motor position raw: %d\n", read_val);
+  position = (double) read_val;
+  setDoubleParam(pC_->motorPosition_, position);
+  printf("ANF2Axis::poll:  Motor position: %f\n", position);
+
+  // Read the moving status of this motor
+  //
+  status = pC_->readReg16(axisNo_, STATUS_1, &read_val, DEFAULT_CONTROLLER_TIMEOUT);
+  //printf("status 1 is 0x%X\n", read_val);
+  
+  // Done logic
+  done = ((read_val & 0x8) >> 3);  // status word 1 bit 3 set to 1 when the motor is not in motion.
+  setIntegerParam(pC_->motorStatusDone_, done);
+  *moving = done ? false:true;
+  printf("done is %d\n", done);
+  
+  // Read the limit status
+  //
+  status = pC_->readReg16(axisNo_, STATUS_2, &read_val, DEFAULT_CONTROLLER_TIMEOUT);
+  printf("status 2 is 0x%X\n", read_val);  
+  
+  limit  = (read_val & 0x1);    // a cw limit has been reached
+  setIntegerParam(pC_->motorStatusHighLimit_, limit);
+  //printf("+limit %d\n", limit);
+    if (limit) {   // reset error and set position so we can move off of the limit
+    // Reset error
+	setClosedLoop(1);
+	// Reset position
+	//printf(" Reset Position\n");
+	setPosition(position);
+  }
+
+  limit  = (read_val & 0x2);    // a ccw limit has been reached
+  setIntegerParam(pC_->motorStatusLowLimit_, limit);
+  //printf("-limit %d\n", limit);
+  if (limit) {   // reset error and set position so we can move off of the limit
+    // Reset error
+	setClosedLoop(1);
+	// Reset position
+	setPosition(position);
+  }
+
+  // test for home
+  
+  // Should be in init routine?  Allows CNEN to be used.
+  setIntegerParam(pC_->motorStatusGainSupport_, 1);
+
+  // Check for the torque status and set accordingly.
+  enabled = (read_val & 0x8000);
+  if (enabled)
+    setIntegerParam(pC_->motorStatusPowerOn_, 1);
+  else
+    setIntegerParam(pC_->motorStatusPowerOn_, 0);
+  
+  // Notify asynMotorController polling routine that we're ready
+  callParamCallbacks();
+
+  return status;
+}
+
+/** Code for iocsh registration */
+
+/* ANF2CreateController */
+static const iocshArg ANF2CreateControllerArg0 = {"Port name", iocshArgString};
+static const iocshArg ANF2CreateControllerArg1 = {"ANF2 In port name", iocshArgString};
+static const iocshArg ANF2CreateControllerArg2 = {"ANF2 Out port name", iocshArgString};
+static const iocshArg ANF2CreateControllerArg3 = {"Number of axes", iocshArgInt};
+static const iocshArg ANF2CreateControllerArg4 = {"Moving poll period (ms)", iocshArgInt};
+static const iocshArg ANF2CreateControllerArg5 = {"Idle poll period (ms)", iocshArgInt};
+static const iocshArg * const ANF2CreateControllerArgs[] = {&ANF2CreateControllerArg0,
+                                                             &ANF2CreateControllerArg1,
+                                                             &ANF2CreateControllerArg2,
+                                                             &ANF2CreateControllerArg3,
+                                                             &ANF2CreateControllerArg4,
+							     &ANF2CreateControllerArg5,};
+static const iocshFuncDef ANF2CreateControllerDef = {"ANF2CreateController", 6, ANF2CreateControllerArgs};
+static void ANF2CreateControllerCallFunc(const iocshArgBuf *args)
+{
+  ANF2CreateController(args[0].sval, args[1].sval, args[2].sval, args[3].ival, args[4].ival, args[5].ival);
+}
+
+
+/* ANF2CreateAxis */
+static const iocshArg ANF2CreateAxisArg0 = {"Port name", iocshArgString};
+static const iocshArg ANF2CreateAxisArg1 = {"Axis number", iocshArgInt};
+static const iocshArg ANF2CreateAxisArg2 = {"Hex config", iocshArgString};
+static const iocshArg * const ANF2CreateAxisArgs[] = {&ANF2CreateAxisArg0,
+                                                             &ANF2CreateAxisArg1,
+                                                             &ANF2CreateAxisArg2};
+static const iocshFuncDef ANF2CreateAxisDef = {"ANF2CreateAxis", 3, ANF2CreateAxisArgs};
+static void ANF2CreateAxisCallFunc(const iocshArgBuf *args)
+{
+  ANF2CreateAxis(args[0].sval, args[1].ival, args[2].sval);
+}
+
+
+static void ANF2Register(void)
+{
+  iocshRegister(&ANF2CreateControllerDef, ANF2CreateControllerCallFunc);
+  iocshRegister(&ANF2CreateAxisDef, ANF2CreateAxisCallFunc);
+}
+
+extern "C" {
+epicsExportRegistrar(ANF2Register);
+}

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -68,6 +68,7 @@ ANF2Controller::ANF2Controller(const char *portName, const char *ANF2InPortName,
     }
     for (i=0; i<MAX_OUTPUT_REGS; i++) {
       status = pasynInt32SyncIO->connect(ANF2OutPortName, i, &pasynUserOutReg_[j][i], NULL);
+      // Maybe send the outputs with Array calls in the future
       //status = pasynInt32ArraySyncIO->connect(ANF2OutPortName, i, &pasynUserOutArrayReg_[j][i], NULL);
     }
   }
@@ -204,6 +205,7 @@ asynStatus ANF2Controller::writeReg16(int axisNo, int axisReg, int output, doubl
   return status ;
 }
 
+// This could be useful in the future, but it isn't needed yet
 /*asynStatus ANF2Controller::writeReg32Array(int axisNo, int axisReg, epicsInt32* output, int nElements, double timeout)
 {
   asynStatus status;
@@ -222,6 +224,8 @@ asynStatus ANF2Controller::writeReg32(int axisNo, int axisReg, int output, doubl
   asynStatus status;
 
   int lower,upper;
+  
+  // This is the way the ANG1 driver does it, and the code doesn't appear to work
   /*float fnum;
 
   fnum = (output / 1000.0);
@@ -243,7 +247,7 @@ asynStatus ANF2Controller::writeReg32(int axisNo, int axisReg, int output, doubl
   axisReg++;
   status = writeReg16(axisNo, axisReg, lower, DEFAULT_CONTROLLER_TIMEOUT);
 
-  // No breaking up the output value required when writing an array
+  // No breaking up the output value required when writing an array - maybe do this in the future
   //status = pasynInt32ArraySyncIO->write(pasynUserOutArrayReg_[axisNo][axisReg], &output, 2, timeout);
 
   return status ;
@@ -303,14 +307,11 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
     pC_(pC)	
 { 
   int status;
-  long long bigConfig;
-  long long configAndSpeed;
   epicsInt32 configBits[2];
   
   axisNo_ = axisNo;
   //this->axisNo_ = axisNo;
 
-  //status = pasynInt32SyncIO->connect(myModbusInputDriver, 0, &pasynUserForceRead_, "MODBUS_READ");
   status = pasynInt32SyncIO->connect(pC_->inputDriver_, 0, &pasynUserForceRead_, "MODBUS_READ");
   if (status) {
     //printf("%s:%s: Error, unable to connect pasynUserForceRead_ to Modbus input driver %s\n", pC_->inputDriver_, pC_->functionName, myModbusInputDriver);
@@ -324,46 +325,34 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   }
   printf("ANF2Axis::ANF2Axis : pasynUserConfWrite_->reason=%d\n", pasynUserConfWrite_->reason);
 
-  epicsThreadSleep(3.0);
+  epicsThreadSleep(1.0);
 
   // Read data that is likely to be stale
   getInfo();
 
   // Send the configuration
   //status = pC_->writeReg32(axisNo_, CONFIG_MSW, config, DEFAULT_CONTROLLER_TIMEOUT);
-  //status = pC_->writeReg16(axisNo_, CONFIG_MSW, 0x8600, DEFAULT_CONTROLLER_TIMEOUT);
-  // Send the configuration bits
-  //status = pasynInt32SyncIO->write(pasynUserConfWrite_, config, DEFAULT_CONTROLLER_TIMEOUT);
-  // Set the start speed to a non-zero value (100)
-  //status = pC_->writeReg16(axisNo_, POS_WR_LWR, 0x0064, DEFAULT_CONTROLLER_TIMEOUT);
-  //epicsThreadSleep(0.01);
-
-  /*bigConfig = (long long) config & 0xFFFFFFFF;
-  configAndSpeed = (bigConfig << 32) | 0x00000064;
-  printf("bigConfig = %lx, configAndSpeed = %lx\n", bigConfig, configAndSpeed);
-  status = pasynInt32SyncIO->write(pasynUserConfWrite_, configAndSpeed, DEFAULT_CONTROLLER_TIMEOUT);*/
-
+ 
+  // Send the configuration (array) 
+  // assemble the configuration bits; set the start speed to a non-zero value (100), which is required for the configuration to be accepted
   configBits[0] = config;
   configBits[1] = 0x00000064;
-  /*status = pasynInt32SyncIO->write(pasynUserConfWrite_, *configBits, DEFAULT_CONTROLLER_TIMEOUT);
-  status = pasynInt32SyncIO->write(pasynUserConfWrite_, *(configBits+1), DEFAULT_CONTROLLER_TIMEOUT);*/
   
   // Does the number of elements refer to the number of 16-bit elements?
-  //status = this->pC_->writeReg32Array(axisNo, CONFIG_MSW, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
-  // 
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
+  // Mabye do it this way in the future
+  //status = this->pC_->writeReg32Array(axisNo, CONFIG_MSW, configBits, 4, DEFAULT_CONTROLLER_TIMEOUT);
 
   // Delay
-  epicsThreadSleep(10.0);
+  epicsThreadSleep(1.0);
 
   // Read the configuration? Or maybe the command registers?
   getInfo();
   
-  //IAMHERE
-  
   // set position to 0
   //setPosition(0);
   setPosition(1337);
+  //setPosition(3141);
   
   // Delay
   epicsThreadSleep(1.0);
@@ -381,12 +370,6 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
  0x2  - External Input (0 = Disabled, 1 = Enabled)
  0x4  - Home Input (0 = Disabled, 1 = Enabled)
  0x8  - 
-
-
-
-
-
-
 
  */
 

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -320,7 +320,6 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32
   /* TODO:
    *  test config bits and set status bits to prevent methods from sending commands that would generate errors
    *  reduce the sleeps to see which ones are necessary
-   *  allow the base speed to be passed as an argument
    */
 
   epicsThreadSleep(0.1);

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -607,8 +607,8 @@ double ANF2Axis::correctAccel(double minVelocity, double maxVelocity, double acc
   accelTime = (maxVelocity - minVelocity) / acceleration;
   newAccel = (maxVelocity - (double)baseSpeed_) / accelTime;
 
-  printf("old acceleration = %lf\n", acceleration);
-  printf("new acceleration = %lf\n", newAccel);
+  //printf("old acceleration = %lf\n", acceleration);
+  //printf("new acceleration = %lf\n", newAccel);
   
   return newAccel;
 }
@@ -780,7 +780,7 @@ asynStatus ANF2Axis::stop(double acceleration)
   epicsInt32 stopReg;
   //static const char *functionName = "ANF2Axis::stop";
   
-  printf("\n  STOP \n\n");
+  //printf("\n  STOP \n\n");
   
   // The stop commands ignore all 32-bit registers beyond the first
   

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -643,7 +643,8 @@ asynStatus ANF2Axis::moveVelocity(double minVelocity, double maxVelocity, double
 
   velo = NINT(fabs(maxVelocity));
 
-  /* ANF2 does not have jog command. Move 1 million steps */
+  /* ANF2 does have a jog command, but don't use it yet */
+  /* ANG1 does not have jog command. Move 1 million steps */
   distance = 1000000;
   if (maxVelocity > 0.) {
     /* This is a positive move in ANF2 coordinates */

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -664,20 +664,21 @@ asynStatus ANF2Axis::moveVelocity(double minVelocity, double maxVelocity, double
 asynStatus ANF2Axis::stop(double acceleration)
 {
   asynStatus status;
-  int stop_bit;
+  epicsInt32 stopReg;
   //static const char *functionName = "ANF2Axis::stop";
   
   printf("\n  STOP \n\n");
   
-  // do nothing (for testing)
-  //return asynSuccess;
+  // The stop commands ignore all 32-bit registers beyond the first
   
-  stop_bit = 0x0;
-  status = pC_->writeReg16(axisNo_, CMD_MSW, stop_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  // Clear the command/configuration register
+  status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, zeroReg_, 1, DEFAULT_CONTROLLER_TIMEOUT);
 
-//  stop_bit = 0x10;      Immediate stop
-  stop_bit = 0x4;      // Hold move
-  status = pC_->writeReg16(axisNo_, CMD_MSW, stop_bit, DEFAULT_CONTROLLER_TIMEOUT);
+  //stopReg = 0x10 << 16;      Immediate stop
+  stopReg = 0x4 << 16;      // Hold move
+  
+  //
+  status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, &stopReg, 1, DEFAULT_CONTROLLER_TIMEOUT);
 
   return status;
 }

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -317,7 +317,7 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
    *  test config bits and set status bits to prevent methods from sending commands that would generate errors
    *  reduce the sleeps to see which ones are necessary
    *  make pasynUserConfWrite_ an output array; create a corresponding controller method to simplify calls
-   *  read encoder position
+   *  allow the base speed to be passed as an argument
    */
 
   epicsThreadSleep(0.1);
@@ -440,6 +440,8 @@ void ANF2Axis::reconfig(epicsInt32 value)
   asynStatus status;
   epicsInt32 confReg[5];
   
+  // TODO: modify this to use the base speed from the parameter, and instead accept a string for a new config
+  
   printf("Reconfiguring axis %i\n", axisNo_);
 
   // Clear the command/configuration register
@@ -478,6 +480,8 @@ void ANF2Axis::reconfig(epicsInt32 value)
   */
 void ANF2Axis::report(FILE *fp, int level)
 {
+  // TODO: make this more useful
+
   if (level > 0) {
     fprintf(fp, "  axis %d\n", axisNo_);
     fprintf(fp, "    this->axisNo_ %i\n", this->axisNo_);
@@ -753,6 +757,8 @@ asynStatus ANF2Axis::poll(bool *moving)
   position = (double) read_val;
   setDoubleParam(pC_->motorPosition_, position);
   //printf("ANF2Axis::poll:  Motor #%i position: %f\n", axisNo_, position);
+
+  //  TODO: read encoder position
 
   // Read the moving status of this motor
   //

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -329,13 +329,10 @@ ANF2Axis::ANF2Axis(ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epi
   // Read data that is likely to be stale
   getInfo();
 
-  // Send the configuration
-  //status = pC_->writeReg32(axisNo_, CONFIG_MSW, config, DEFAULT_CONTROLLER_TIMEOUT);
- 
   // Send the configuration (array) 
   // assemble the configuration bits; set the start speed to a non-zero value (100), which is required for the configuration to be accepted
-  confReg_[0] = config;
-  confReg_[1] = 0x00000064;
+  confReg_[CONFIGURATION] = config;
+  confReg_[BASE_SPEED] = 0x00000064;
   
   // Write all the registers
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, confReg_, 5, DEFAULT_CONTROLLER_TIMEOUT);
@@ -447,11 +444,11 @@ void ANF2Axis::reconfig()
   status = pasynInt32ArraySyncIO->write(pasynUserConfWrite_, confReg, 5, DEFAULT_CONTROLLER_TIMEOUT);
 
   // Construct the new config
-  confReg[0] = 0x86000000;
-  confReg[1] = 0x00000064;
-  //confReg[2] = 0x0;
-  //confReg[3] = 0x0;
-  //confReg[4] = 0x0;
+  confReg[CONFIGURATION] = 0x86000000;
+  confReg[BASE_SPEED] = 0x00000064;
+  //confReg[HOME_TIMEOUT] = 0x0;
+  //confReg[CONFIG_REG_3] = 0x0;
+  //confReg[CONFIG_REG_4] = 0x0;
 
   epicsThreadSleep(2.0);
   getInfo();

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -454,10 +454,12 @@ asynStatus ANF2Axis::sendAccelAndVelocity(double acceleration, double velocity)
   // Therefore need to limit range received by motor record from 1000 to 5e6 steps/sec/sec
   if (acceleration < 1000) {
     // print message noting that accel has been capped low
+    //printf("Acceleration is < 1000: %lf\n", acceleration);
     acceleration = 1000;
   }
   if (acceleration > 5000000) {
     // print message noting that accel has been capped high
+    //printf("Acceleration is > 5000: %lf\n", acceleration);
     acceleration = 5000000;
   }
   // ANF2 acceleration units are steps/millisecond/second, so we divide by 1000 here
@@ -483,8 +485,8 @@ asynStatus ANF2Axis::move(double position, int relative, double minVelocity, dou
     distance = NINT(position);
     status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
     
-    //move_bit = 0x0;
-    //status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+    move_bit = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
     
     move_bit = 0x2;
     status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
@@ -497,8 +499,8 @@ asynStatus ANF2Axis::move(double position, int relative, double minVelocity, dou
     printf(" ** distance = %d\n", distance);
     status = pC_->writeReg32(axisNo_, POS_WR_UPR, distance, DEFAULT_CONTROLLER_TIMEOUT);
     
-    //move_bit = 0x0;
-    //status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
+    move_bit = 0x0;
+    status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);
     
     move_bit = 0x1;
     status = pC_->writeReg16(axisNo_, CMD_MSW, move_bit, DEFAULT_CONTROLLER_TIMEOUT);	

--- a/motorApp/AMCISrc/ANF2Driver.cpp
+++ b/motorApp/AMCISrc/ANF2Driver.cpp
@@ -140,7 +140,7 @@ void ANF2Controller::doStartPoller(double movingPollPeriod, double idlePollPerio
 void ANF2Controller::report(FILE *fp, int level)
 {
   int i, j;
-  ANF2Axis* pAxis[numAxes_];
+  ANF2Axis* pAxis[MAX_AXES];
   
   fprintf(fp, "====================================\n");
   fprintf(fp, "ANF2 motor driver:\n");

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -79,7 +79,7 @@ private:
                                    *   Abbreviated because it is used very frequently */
   asynStatus sendAccelAndVelocity(double accel, double velocity);
   void getInfo();
-  void reconfig();
+  void reconfig(epicsInt32 value);
   void zeroRegisters(epicsInt32 *reg);
   asynUser *pasynUserForceRead_;
   asynUser *pasynUserConfWrite_;
@@ -87,6 +87,7 @@ private:
   epicsInt32 config_;
   epicsInt32 motionReg_[5];
   epicsInt32 confReg_[5];
+  epicsInt32 zeroReg_[5];
 
 friend class ANF2Controller;
 };

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -65,7 +65,7 @@ class ANF2Axis : public asynMotorAxis
 {
 public:
   /* These are the methods we override from the base class */
-  ANF2Axis(class ANF2Controller *pC, int axisNo, epicsInt32 config);
+  ANF2Axis(class ANF2Controller *pC, int axisNo, epicsInt32 config, epicsInt32 baseSpeed, epicsInt32 homingTimeout);
   void report(FILE *fp, int level);
   asynStatus move(double position, int relative, double min_velocity, double max_velocity, double acceleration);
   asynStatus moveVelocity(double min_velocity, double max_velocity, double acceleration);
@@ -84,6 +84,8 @@ private:
   void zeroRegisters(epicsInt32 *reg);
   asynUser *pasynUserForceRead_;
   int axisNo_;
+  epicsInt32 baseSpeed_;
+  epicsInt32 homingTimeout_;
   epicsInt32 config_;
   epicsInt32 motionReg_[5];
   epicsInt32 confReg_[5];

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -46,13 +46,12 @@ K. Goetze 2014-03-24
 // Not used must equal zero #define RESERVED 8
 // Not used must equal zero #define RESERVED 9
 
-/*** Output Configuration Registers ***/
-#define CONFIG_MSW   0
-#define CONFIG_LSW   1
-#define BASE_SPD_MSW 2
-#define BASE_SPD_LSW 3
-#define HOME_TIMEOUT 4
-
+/*** Output Configuration Registers (32-bit) ***/
+#define CONFIGURATION 0
+#define BASE_SPEED    1
+#define HOME_TIMEOUT  2
+#define CONFIG_REG_3  3
+#define CONFIG_REG_4  4
 
 // No. of controller-specific parameters
 #define NUM_ANF2_PARAMS 2

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -15,7 +15,8 @@ K. Goetze 2014-03-24
 //#include <asynInt32Array.h>
 #include <asynInt32ArraySyncIO.h>
 
-#define MAX_AXES 2
+#define MAX_MODULES 6
+#define MAX_AXES_PER_MODULE 2
 
 #define MAX_INPUT_REGS 10
 #define MAX_OUTPUT_REGS 10
@@ -94,15 +95,15 @@ friend class ANF2Controller;
 
 class ANF2Controller : public asynMotorController {
 public:
-  ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numAxes, double movingPollPeriod, double idlePollPeriod);
-  void doStartPoller();
+  ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numModules, int axesPerModule);
+  void doStartPoller(double movingPollPeriod, double idlePollPeriod);
   
   void report(FILE *fp, int level);
   ANF2Axis* getAxis(asynUser *pasynUser);
   ANF2Axis* getAxis(int axisNo); 
-  asynUser *pasynUserInReg_[MAX_AXES][MAX_INPUT_REGS];
-  asynUser *pasynUserOutReg_[MAX_AXES][MAX_OUTPUT_REGS]; 
-  //asynUser *pasynUserOutArrayReg_[MAX_AXES][MAX_OUTPUT_REGS]; 
+  asynUser *pasynUserInReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_INPUT_REGS];
+  asynUser *pasynUserOutReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_OUTPUT_REGS]; 
+  //asynUser *pasynUserOutArrayReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_OUTPUT_REGS]; 
 
   /* These are the methods that we override from asynMotorDriver */
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -123,6 +124,9 @@ private:
   asynStatus readReg16(int, int, epicsInt32*, double);
   asynStatus readReg32(int, int, epicsInt32*, double);
   char *inputDriver_;
+  int numAxes_;
+  int numModules_;
+  int axesPerModule_;
   double movingPollPeriod_;
   double idlePollPeriod_;
   int axesCreated_;

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -55,11 +55,12 @@ K. Goetze 2014-03-24
 #define CONFIG_REG_4  4
 
 // No. of controller-specific parameters
-#define NUM_ANF2_PARAMS 2
+#define NUM_ANF2_PARAMS 3
 
 /** drvInfo strings for extra parameters that the ACR controller supports */
+#define ANF2ResetErrorsString       "ANF2_RESET_ERRORS"
 #define ANF2GetInfoString           "ANF2_GET_INFO"
-#define ANF2ReconfigString           "ANF2_RECONFIG"
+#define ANF2ReconfigString          "ANF2_RECONFIG"
 
 class ANF2Axis : public asynMotorAxis
 {
@@ -80,6 +81,7 @@ private:
                                    *   Abbreviated because it is used very frequently */
   asynStatus sendAccelAndVelocity(double accel, double velocity);
   double correctAccel(double minVelocity, double maxVelocity, double acceleration);
+  asynStatus resetErrors();
   void getInfo();
   epicsInt32 inputReg_[10];
   void reconfig(epicsInt32 value);
@@ -135,8 +137,9 @@ public:
   /* These are the methods that are new to this class */
   
 protected:
-  int ANF2GetInfo_;          /**< Jerk time parameter index */        
-  int ANF2Reconfig_;          /**< Jerk time parameter index */        
+  int ANF2ResetErrors_;     /** Reset Errors parameter index */
+  int ANF2GetInfo_;          /**< Get Info parameter index */        
+  int ANF2Reconfig_;          /**< Reconfig parameter index */        
 
 
 private:

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -81,11 +81,13 @@ private:
   asynStatus sendAccelAndVelocity(double accel, double velocity);
   void getInfo();
   void reconfig();
+  void zeroRegisters(epicsInt32 *reg);
   asynUser *pasynUserForceRead_;
   asynUser *pasynUserConfWrite_;
   int axisNo_;
   epicsInt32 config_;
-  epicsInt32 registers_[5];
+  epicsInt32 motionReg_[5];
+  epicsInt32 confReg_[5];
 
 friend class ANF2Controller;
 };

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -102,7 +102,6 @@ public:
   ANF2Axis* getAxis(asynUser *pasynUser);
   ANF2Axis* getAxis(int axisNo); 
   asynUser *pasynUserInReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_INPUT_REGS];
-  asynUser *pasynUserOutReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_OUTPUT_REGS]; 
   //asynUser *pasynUserOutArrayReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_OUTPUT_REGS]; 
 
   /* These are the methods that we override from asynMotorDriver */

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -83,6 +83,7 @@ private:
   asynUser *pasynUserConfWrite_;
   int axisNo_;
   epicsInt32 config_;
+  epicsInt32 registers_[5];
 
 friend class ANF2Controller;
 };

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -62,7 +62,7 @@ class ANF2Axis : public asynMotorAxis
 {
 public:
   /* These are the methods we override from the base class */
-  ANF2Axis(class ANF2Controller *pC, int axisNo, epicsInt32 config);
+  ANF2Axis(class ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epicsInt32 config);
   void report(FILE *fp, int level);
   asynStatus move(double position, int relative, double min_velocity, double max_velocity, double acceleration);
   asynStatus moveVelocity(double min_velocity, double max_velocity, double acceleration);
@@ -78,6 +78,7 @@ private:
   asynStatus sendAccelAndVelocity(double accel, double velocity);
   void getInfo();
   asynUser *pasynUserForceRead_;
+  asynUser *pasynUserConfWrite_;
   int axisNo_;
   epicsInt32 config_;
 

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -81,6 +81,7 @@ private:
   asynStatus sendAccelAndVelocity(double accel, double velocity);
   double correctAccel(double minVelocity, double maxVelocity, double acceleration);
   void getInfo();
+  epicsInt32 inputReg_[10];
   void reconfig(epicsInt32 value);
   void zeroRegisters(epicsInt32 *reg);
   asynUser *pasynUserForceRead_;

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -12,6 +12,8 @@ K. Goetze 2014-03-24
 
 #include "asynMotorController.h"
 #include "asynMotorAxis.h"
+//#include <asynInt32Array.h>
+#include <asynInt32ArraySyncIO.h>
 
 #define MAX_AXES 2
 
@@ -94,8 +96,7 @@ public:
   ANF2Axis* getAxis(int axisNo); 
   asynUser *pasynUserInReg_[MAX_AXES][MAX_INPUT_REGS];
   asynUser *pasynUserOutReg_[MAX_AXES][MAX_OUTPUT_REGS]; 
-//  asynUser *pasynUserForceRead_;
-
+  //asynUser *pasynUserOutArrayReg_[MAX_AXES][MAX_OUTPUT_REGS]; 
 
   /* These are the methods that we override from asynMotorDriver */
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -111,6 +112,7 @@ protected:
 private:
   asynStatus writeReg16(int, int, int, double);
   asynStatus writeReg32(int, int, int, double);
+  //asynStatus writeReg32Array(int, int, epicsInt32*, int, double);
   asynStatus readReg16(int, int, epicsInt32*, double);
   asynStatus readReg32(int, int, epicsInt32*, double);
   char *inputDriver_;

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -95,7 +95,8 @@ friend class ANF2Controller;
 class ANF2Controller : public asynMotorController {
 public:
   ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numAxes, double movingPollPeriod, double idlePollPeriod);
-
+  void doStartPoller();
+  
   void report(FILE *fp, int level);
   ANF2Axis* getAxis(asynUser *pasynUser);
   ANF2Axis* getAxis(int axisNo); 
@@ -122,6 +123,8 @@ private:
   asynStatus readReg16(int, int, epicsInt32*, double);
   asynStatus readReg32(int, int, epicsInt32*, double);
   char *inputDriver_;
+  double movingPollPeriod_;
+  double idlePollPeriod_;
   int axesCreated_;
 
 friend class ANF2Axis;

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -58,7 +58,7 @@ K. Goetze 2014-03-24
 #define NUM_ANF2_PARAMS 1 
 
 /** drvInfo strings for extra parameters that the ACR controller supports */
-#define ANF2JerkString           "ANF2_JERK"
+#define ANF2GetInfoString           "ANF2_GET_INFO"
 
 class ANF2Axis : public asynMotorAxis
 {
@@ -106,7 +106,7 @@ public:
   /* These are the methods that are new to this class */
   
 protected:
-  int ANF2Jerk_;          /**< Jerk time parameter index */        
+  int ANF2GetInfo_;          /**< Jerk time parameter index */        
 
 
 private:

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -1,0 +1,116 @@
+/*
+FILENAME...   ANF2Driver.h
+USAGE...      Motor driver support for the AMCI ANF2 controller.
+
+Based on MCB-4B driver written by
+Mark Rivers
+March 1, 2012
+
+K. Goetze 2014-03-24
+
+*/
+
+#include "asynMotorController.h"
+#include "asynMotorAxis.h"
+
+#define MAX_AXES 2
+
+#define MAX_INPUT_REGS 10
+#define MAX_OUTPUT_REGS 10
+
+#define AXIS_REG_OFFSET 10
+
+/*** Input CMD Registers ***/
+#define STATUS_1   0
+#define STATUS_2   1
+#define POS_RD_UPR 2
+#define POS_RD_LWR 3
+#define EN_POS_UPR 4
+#define EN_POS_LWR 5
+#define EN_CAP_UPR 6
+#define EN_CAP_LWR 7
+// Not used must equal zero #define RESERVED 8
+#define NET_CONN   9
+
+/*** Output CMD Registers ***/
+#define CMD_MSW    0  // module 0 starts at register address 1024.  This is set in drvModbusAsynConfigure.
+#define CMD_LSW    1
+#define POS_WR_UPR 2
+#define POS_WR_LWR 3
+#define SPD_UPR    4
+#define SPD_LWR    5
+#define ACCEL      6
+#define DECEL      7
+// Not used must equal zero #define RESERVED 8
+// Not used must equal zero #define RESERVED 9
+
+/*** Output Configuration Registers ***/
+#define CONFIG_MSW   0
+#define CONFIG_LSW   1
+#define BASE_SPD_MSW 2
+#define BASE_SPD_LSW 3
+#define HOME_TIMEOUT 4
+
+
+// No. of controller-specific parameters
+#define NUM_ANF2_PARAMS 1 
+
+/** drvInfo strings for extra parameters that the ACR controller supports */
+#define ANF2JerkString           "ANF2_JERK"
+
+class ANF2Axis : public asynMotorAxis
+{
+public:
+  /* These are the methods we override from the base class */
+  ANF2Axis(class ANF2Controller *pC, int axisNo, epicsInt32 config);
+  void report(FILE *fp, int level);
+  asynStatus move(double position, int relative, double min_velocity, double max_velocity, double acceleration);
+  asynStatus moveVelocity(double min_velocity, double max_velocity, double acceleration);
+  asynStatus home(double min_velocity, double max_velocity, double acceleration, int forwards);
+  asynStatus stop(double acceleration);
+  asynStatus poll(bool *moving);
+  asynStatus setPosition(double position);
+  asynStatus setClosedLoop(bool closedLoop);
+
+private:
+  ANF2Controller *pC_;          /**< Pointer to the asynMotorController to which this axis belongs.
+                                   *   Abbreviated because it is used very frequently */
+  asynStatus sendAccelAndVelocity(double accel, double velocity);
+  asynUser *pasynUserForceRead_;
+
+friend class ANF2Controller;
+};
+
+class ANF2Controller : public asynMotorController {
+public:
+  ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numAxes, double movingPollPeriod, double idlePollPeriod);
+
+  void report(FILE *fp, int level);
+  ANF2Axis* getAxis(asynUser *pasynUser);
+  ANF2Axis* getAxis(int axisNo); 
+  asynUser *pasynUserInReg_[MAX_AXES][MAX_INPUT_REGS];
+  asynUser *pasynUserOutReg_[MAX_AXES][MAX_OUTPUT_REGS]; 
+//  asynUser *pasynUserForceRead_;
+
+
+  /* These are the methods that we override from asynMotorDriver */
+  asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
+  //asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);
+  //void report(FILE *fp, int level);
+
+  /* These are the methods that are new to this class */
+  
+protected:
+  int ANF2Jerk_;          /**< Jerk time parameter index */        
+
+
+private:
+  asynStatus writeReg16(int, int, int, double);
+  asynStatus writeReg32(int, int, int, double);
+  asynStatus readReg16(int, int, epicsInt32*, double);
+  asynStatus readReg32(int, int, epicsInt32*, double);
+  char *inputDriver_;
+  int axisNo_;
+
+friend class ANF2Axis;
+};

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -2,11 +2,9 @@
 FILENAME...   ANF2Driver.h
 USAGE...      Motor driver support for the AMCI ANF2 controller.
 
-Based on MCB-4B driver written by
-Mark Rivers
-March 1, 2012
+Kevin Peterson
 
-K. Goetze 2014-03-24
+Based on the AMCI ANG1 Model 3 device driver written by Kurt Goetze
 
 */
 

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -15,8 +15,7 @@ K. Goetze 2014-03-24
 //#include <asynInt32Array.h>
 #include <asynInt32ArraySyncIO.h>
 
-#define MAX_MODULES 6
-#define MAX_AXES_PER_MODULE 2
+#define MAX_AXES 12
 
 #define MAX_INPUT_REGS 10
 #define MAX_OUTPUT_REGS 10
@@ -115,14 +114,14 @@ friend class ANF2Controller;
 
 class ANF2Controller : public asynMotorController {
 public:
-  ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numModules, int axesPerModule);
+  ANF2Controller(const char *portName, const char *ANF2InPortName, const char *ANF2OutPortName, int numAxes);
   void doStartPoller(double movingPollPeriod, double idlePollPeriod);
   
   void report(FILE *fp, int level);
   ANF2Axis* getAxis(asynUser *pasynUser);
   ANF2Axis* getAxis(int axisNo); 
-  asynUser *pasynUserInReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_INPUT_REGS];
-  asynUser *pasynUserOutReg_[MAX_MODULES*MAX_AXES_PER_MODULE];
+  asynUser *pasynUserInReg_[MAX_AXES][MAX_INPUT_REGS];
+  asynUser *pasynUserOutReg_[MAX_AXES];
 
   /* These are the methods that we override from asynMotorDriver */
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -76,6 +76,7 @@ private:
   ANF2Controller *pC_;          /**< Pointer to the asynMotorController to which this axis belongs.
                                    *   Abbreviated because it is used very frequently */
   asynStatus sendAccelAndVelocity(double accel, double velocity);
+  void getInfo();
   asynUser *pasynUserForceRead_;
   int axisNo_;
   epicsInt32 config_;
@@ -112,6 +113,7 @@ private:
   asynStatus readReg16(int, int, epicsInt32*, double);
   asynStatus readReg32(int, int, epicsInt32*, double);
   char *inputDriver_;
+  int axesCreated_;
 
 friend class ANF2Axis;
 };

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -92,6 +92,7 @@ private:
   epicsInt32 motionReg_[5];
   epicsInt32 confReg_[5];
   epicsInt32 zeroReg_[5];
+  bool jogging_;
   // Configuration bits
   short CaptInput_;
   short ExtInput_;

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -50,12 +50,12 @@ K. Goetze 2014-03-24
 #define CONFIG_REG_4  4
 
 // No. of controller-specific parameters
-#define NUM_ANF2_PARAMS 3
+#define NUM_ANF2_PARAMS 2
 
 /** drvInfo strings for extra parameters that the ACR controller supports */
 #define ANF2ResetErrorsString       "ANF2_RESET_ERRORS"
 #define ANF2GetInfoString           "ANF2_GET_INFO"
-#define ANF2ReconfigString          "ANF2_RECONFIG"
+//#define ANF2ReconfigString          "ANF2_RECONFIG"
 
 class ANF2Axis : public asynMotorAxis
 {
@@ -79,7 +79,7 @@ private:
   asynStatus resetErrors();
   void getInfo();
   epicsInt32 inputReg_[10];
-  void reconfig(epicsInt32 value);
+  //void reconfig(epicsInt32 value);
   void zeroRegisters(epicsInt32 *reg);
   asynUser *pasynUserForceRead_;
   int axisNo_;
@@ -134,8 +134,7 @@ public:
 protected:
   int ANF2ResetErrors_;     /** Reset Errors parameter index */
   int ANF2GetInfo_;          /**< Get Info parameter index */        
-  int ANF2Reconfig_;          /**< Reconfig parameter index */        
-
+  //int ANF2Reconfig_;          /**< Reconfig parameter index */        
 
 private:
   asynStatus writeReg16(int, int, int, double);

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -55,10 +55,11 @@ K. Goetze 2014-03-24
 
 
 // No. of controller-specific parameters
-#define NUM_ANF2_PARAMS 1 
+#define NUM_ANF2_PARAMS 2
 
 /** drvInfo strings for extra parameters that the ACR controller supports */
 #define ANF2GetInfoString           "ANF2_GET_INFO"
+#define ANF2ReconfigString           "ANF2_RECONFIG"
 
 class ANF2Axis : public asynMotorAxis
 {
@@ -79,6 +80,7 @@ private:
                                    *   Abbreviated because it is used very frequently */
   asynStatus sendAccelAndVelocity(double accel, double velocity);
   void getInfo();
+  void reconfig();
   asynUser *pasynUserForceRead_;
   asynUser *pasynUserConfWrite_;
   int axisNo_;
@@ -108,6 +110,7 @@ public:
   
 protected:
   int ANF2GetInfo_;          /**< Jerk time parameter index */        
+  int ANF2Reconfig_;          /**< Jerk time parameter index */        
 
 
 private:

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -23,7 +23,7 @@ K. Goetze 2014-03-24
 
 #define AXIS_REG_OFFSET 10
 
-/*** Input CMD Registers ***/
+/*** Input CMD Registers (16-bit) ***/
 #define STATUS_1   0
 #define STATUS_2   1
 #define POS_RD_UPR 2
@@ -35,17 +35,12 @@ K. Goetze 2014-03-24
 // Not used must equal zero #define RESERVED 8
 #define NET_CONN   9
 
-/*** Output CMD Registers ***/
-#define CMD_MSW    0  // module 0 starts at register address 1024.  This is set in drvModbusAsynConfigure.
-#define CMD_LSW    1
-#define POS_WR_UPR 2
-#define POS_WR_LWR 3
-#define SPD_UPR    4
-#define SPD_LWR    5
-#define ACCEL      6
-#define DECEL      7
-// Not used must equal zero #define RESERVED 8
-// Not used must equal zero #define RESERVED 9
+/*** Output Command Registers (32-bit) ***/
+#define COMMAND       0
+#define POSITION      1
+#define SPEED         2
+#define ACCEL_DECEL   3
+#define CMD_REG_4     4
 
 /*** Output Configuration Registers (32-bit) ***/
 #define CONFIGURATION 0

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -65,7 +65,7 @@ class ANF2Axis : public asynMotorAxis
 {
 public:
   /* These are the methods we override from the base class */
-  ANF2Axis(class ANF2Controller *pC, const char *ANF2ConfName, int axisNo, epicsInt32 config);
+  ANF2Axis(class ANF2Controller *pC, int axisNo, epicsInt32 config);
   void report(FILE *fp, int level);
   asynStatus move(double position, int relative, double min_velocity, double max_velocity, double acceleration);
   asynStatus moveVelocity(double min_velocity, double max_velocity, double acceleration);
@@ -83,7 +83,6 @@ private:
   void reconfig(epicsInt32 value);
   void zeroRegisters(epicsInt32 *reg);
   asynUser *pasynUserForceRead_;
-  asynUser *pasynUserConfWrite_;
   int axisNo_;
   epicsInt32 config_;
   epicsInt32 motionReg_[5];
@@ -102,7 +101,7 @@ public:
   ANF2Axis* getAxis(asynUser *pasynUser);
   ANF2Axis* getAxis(int axisNo); 
   asynUser *pasynUserInReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_INPUT_REGS];
-  //asynUser *pasynUserOutArrayReg_[MAX_MODULES*MAX_AXES_PER_MODULE][MAX_OUTPUT_REGS]; 
+  asynUser *pasynUserOutReg_[MAX_MODULES*MAX_AXES_PER_MODULE];
 
   /* These are the methods that we override from asynMotorDriver */
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -119,7 +118,7 @@ protected:
 private:
   asynStatus writeReg16(int, int, int, double);
   asynStatus writeReg32(int, int, int, double);
-  //asynStatus writeReg32Array(int, int, epicsInt32*, int, double);
+  asynStatus writeReg32Array(int, epicsInt32*, int, double);
   asynStatus readReg16(int, int, epicsInt32*, double);
   asynStatus readReg32(int, int, epicsInt32*, double);
   char *inputDriver_;

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -77,6 +77,8 @@ private:
                                    *   Abbreviated because it is used very frequently */
   asynStatus sendAccelAndVelocity(double accel, double velocity);
   asynUser *pasynUserForceRead_;
+  int axisNo_;
+  epicsInt32 config_;
 
 friend class ANF2Controller;
 };
@@ -110,7 +112,6 @@ private:
   asynStatus readReg16(int, int, epicsInt32*, double);
   asynStatus readReg32(int, int, epicsInt32*, double);
   char *inputDriver_;
-  int axisNo_;
 
 friend class ANF2Axis;
 };

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -79,6 +79,7 @@ private:
   ANF2Controller *pC_;          /**< Pointer to the asynMotorController to which this axis belongs.
                                    *   Abbreviated because it is used very frequently */
   asynStatus sendAccelAndVelocity(double accel, double velocity);
+  double correctAccel(double minVelocity, double maxVelocity, double acceleration);
   void getInfo();
   void reconfig(epicsInt32 value);
   void zeroRegisters(epicsInt32 *reg);

--- a/motorApp/AMCISrc/ANF2Driver.h
+++ b/motorApp/AMCISrc/ANF2Driver.h
@@ -88,6 +88,25 @@ private:
   epicsInt32 motionReg_[5];
   epicsInt32 confReg_[5];
   epicsInt32 zeroReg_[5];
+  // Configuration bits
+  short CaptInput_;
+  short ExtInput_;
+  short HomeInput_;
+  short CWInput_;
+  short CCWInput_;
+  short BHPO_;
+  short QuadEnc_;
+  short DiagFbk_; 
+  short OutPulse_;
+  short HomeOp_;
+  short CardAxis_;
+  short OpMode_;
+  // LSW
+  short CaptInputAS_;
+  short ExtInputAS_;
+  short HomeInputAS_;
+  short CWInputAS_;
+  short CCWInputAS_;
 
 friend class ANF2Controller;
 };

--- a/motorApp/AMCISrc/ANF2Support.dbd
+++ b/motorApp/AMCISrc/ANF2Support.dbd
@@ -1,0 +1,2 @@
+#registrar(ANF2MotorRegister)
+registrar(ANF2Register)

--- a/motorApp/AMCISrc/Makefile
+++ b/motorApp/AMCISrc/Makefile
@@ -12,10 +12,13 @@ LIBRARY_IOC += AMCI
 
 # motorRecord.h will be created from motorRecord.dbd
 # install devMotorSoft.dbd into <top>/dbd
+DBD += AMCISupport.dbd
 DBD += ANG1Support.dbd
+DBD += ANF2Support.dbd
 
 # The following are compiled and added to the Support library
 AMCI_SRCS += ANG1Driver.cpp
+AMCI_SRCS += ANF2Driver.cpp
 
 AMCI_LIBS += motor
 AMCI_LIBS += asyn

--- a/motorApp/AMCISrc/README_ANF2.md
+++ b/motorApp/AMCISrc/README_ANF2.md
@@ -1,0 +1,71 @@
+# AMCI ANF2 
+
+Asyn model 3 driver support for the AMCI ANF2 stepper motor controller
+
+Modbus/TCP communication, using Mark Rivers' modbus module
+
+## Supported Controller Models
+
+The following ANF controller versions are supported:
+
+ANF1E: 1-axis stepper controller, modbus tcp/ip
+ANF1:  1-axis stepper controller, no network interface
+ANF2E: 2-axis stepper controller, modbus tcp/ip
+ANF2:  2-axis stepper controller, no network interface
+
+A stack of controller can contain up to 6 modules, one of
+which needs to have the ethernet option.  A single-channel
+implementation would need the module with ethernet.
+
+## Vendor Software
+
+ANF2 configuration software is available from AMCI's website:
+
+www.amci.com/product-software.asp
+
+Note: The AMCI Net Configurator only works (allows a motor to be moved) if
+the controller is configured for  EtherNet/IP, however, the EPICS support 
+requires the device to be configured for Modbus-TCP.
+
+## Controller Quirks
+
+* The controller doesn't allow absolute moves when a limit is active; 
+The only way to move a motor off of a limit is by jogging.
+
+* The base speed is set when an axis is configured.  This driver corrects 
+the acceleration sent by the motor record (VBAS isn't guaranteed to match
+the base speed) and sends the acceleration necessary to achieve the desired
+acceleration time.
+
+* The controller doesn't remember its configuration after it is power-cycled.
+
+* Sending the configuration to the controller invalidates the position
+requiring either a home search or the redefinition of the current position.
+
+* The configuration can't be read after a configuration is accepted by the
+controller, after which it automatically switches into command mode.
+
+* The command to stop an abosolute move generates an error if a jog is in 
+progress.  The command to stop a jog doesn't stop an absolute move.
+
+## Controller Configuration
+
+The AMCI Net Configurator can be used to:
+
+* Change the ip address from the default (192.168.0.50)
+
+* Change the protocol to Modbus-TCP
+
+* Determine hex config strings for each axis
+
+### Example hex configurations
+
+The AMCI Net Configurator can be used to generate hex configurations.  Here are some example:
+```
+0x86000000 - Step & Direction pulses, Diagnostic Feedback, No home switch, No limits
+0x86280000 - Step & Direction pulses, Diagnostic Feedback, No home switch, Active-low CW/CCW limits
+0x84000000 - Step & Direction pulses, No Feedback, No home switch, No Limits
+0x84280000 - Step & Direction pulses, No Feedback, No home switch, Active-low CW/CCW limits
+0x842C0004 - Step & Direction pulses, No Feedback, Active-high home switch, Active-low CW/CCW limits
+0x85280000 - Step & Direction pulses, Quadrature Feedback, No home switch, Active-low CW/CCW limits
+```

--- a/motorApp/AMCISrc/README_ANF2.md
+++ b/motorApp/AMCISrc/README_ANF2.md
@@ -7,12 +7,12 @@ Modbus/TCP communication, using Mark Rivers' modbus module
 ## Supported Controller Models
 
 The following ANF controller versions are supported:
-
+```
 ANF1E: 1-axis stepper controller, modbus tcp/ip
 ANF1:  1-axis stepper controller, no network interface
 ANF2E: 2-axis stepper controller, modbus tcp/ip
 ANF2:  2-axis stepper controller, no network interface
-
+```
 A stack of controller can contain up to 6 modules, one of
 which needs to have the ethernet option.  A single-channel
 implementation would need the module with ethernet.
@@ -30,7 +30,7 @@ requires the device to be configured for Modbus-TCP.
 ## Controller Quirks
 
 * The controller doesn't allow absolute moves when a limit is active; 
-The only way to move a motor off of a limit is by jogging.
+The only way to move a motor off of a limit is by **jogging**.
 
 * The base speed is set when an axis is configured.  This driver corrects 
 the acceleration sent by the motor record (VBAS isn't guaranteed to match
@@ -58,9 +58,8 @@ The AMCI Net Configurator can be used to:
 
 * Determine hex config strings for each axis
 
-### Example hex configurations
+### Example axis configuration
 
-The AMCI Net Configurator can be used to generate hex configurations.  Here are some example:
 ```
 0x86000000 - Step & Direction pulses, Diagnostic Feedback, No home switch, No limits
 0x86280000 - Step & Direction pulses, Diagnostic Feedback, No home switch, Active-low CW/CCW limits

--- a/motorApp/Db/ANF2Aux.template
+++ b/motorApp/Db/ANF2Aux.template
@@ -1,0 +1,9 @@
+# Database for extra PVs for AMCI ANG1 controllers
+
+record(bo,"$(P)$(R)GetInfo") {
+    field(DESC,"Get Info")
+    field(PINI, "0")
+    field(VAL,"0")
+    field(DTYP, "asynInt32")
+    field(OUT,"@asyn($(PORT),$(ADDR))ANF2_GET_INFO")
+}

--- a/motorApp/Db/ANF2Aux.template
+++ b/motorApp/Db/ANF2Aux.template
@@ -18,10 +18,11 @@ record(bo,"$(P)$(R)GetInfo") {
     field(OUT,"@asyn($(PORT),$(ADDR))ANF2_GET_INFO")
 }
 
-record(longout,"$(P)$(R)Reconfig") {
-    field(DESC,"Reconfig")
-    field(PINI, "0")
-    field(VAL,"0")
-    field(DTYP, "asynInt32")
-    field(OUT,"@asyn($(PORT),$(ADDR))ANF2_RECONFIG")
-}
+# Reconfig isn't yet implemented in a generally-useful way
+#record(longout,"$(P)$(R)Reconfig") {
+#    field(DESC,"Reconfig")
+#    field(PINI, "0")
+#    field(VAL,"0")
+#    field(DTYP, "asynInt32")
+#    field(OUT,"@asyn($(PORT),$(ADDR))ANF2_RECONFIG")
+#}

--- a/motorApp/Db/ANF2Aux.template
+++ b/motorApp/Db/ANF2Aux.template
@@ -7,3 +7,11 @@ record(bo,"$(P)$(R)GetInfo") {
     field(DTYP, "asynInt32")
     field(OUT,"@asyn($(PORT),$(ADDR))ANF2_GET_INFO")
 }
+
+record(bo,"$(P)$(R)Reconfig") {
+    field(DESC,"Reconfig")
+    field(PINI, "0")
+    field(VAL,"0")
+    field(DTYP, "asynInt32")
+    field(OUT,"@asyn($(PORT),$(ADDR))ANF2_RECONFIG")
+}

--- a/motorApp/Db/ANF2Aux.template
+++ b/motorApp/Db/ANF2Aux.template
@@ -1,5 +1,15 @@
 # Database for extra PVs for AMCI ANG1 controllers
 
+record(bo,"$(P)$(R)ResetErrors") {
+    field(DESC,"Reset Errors")
+    field(PINI, "0")
+    field(VAL,"0")
+    field(DTYP, "asynInt32")
+    field(OUT,"@asyn($(PORT),$(ADDR))ANF2_RESET_ERRORS")
+    field(ZNAM, "Done")
+    field(ONAM, "Reset")
+}
+
 record(bo,"$(P)$(R)GetInfo") {
     field(DESC,"Get Info")
     field(PINI, "0")

--- a/motorApp/Db/ANF2Aux.template
+++ b/motorApp/Db/ANF2Aux.template
@@ -8,7 +8,7 @@ record(bo,"$(P)$(R)GetInfo") {
     field(OUT,"@asyn($(PORT),$(ADDR))ANF2_GET_INFO")
 }
 
-record(bo,"$(P)$(R)Reconfig") {
+record(longout,"$(P)$(R)Reconfig") {
     field(DESC,"Reconfig")
     field(PINI, "0")
     field(VAL,"0")


### PR DESCRIPTION
Added support for the following models of [AMCI ANF controllers](https://www.amci.com/plc-automation-products/anf1-anf2-anynet-io-motion-controller-networked-io):

* ANF1E
* ANF1
* ANF2E
* ANF2