### PR TITLE
Patch from Takashi Nakamoto to prevent segfault when XPSConfigAxis isn't called before using a motor.

### DIFF
--- a/motorApp/NewportSrc/drvXPSAsyn.c
+++ b/motorApp/NewportSrc/drvXPSAsyn.c
@@ -612,6 +612,10 @@ static int motorAxisSetDouble(AXIS_HDL pAxis, motorAxisParam_t function, double 
     double positions[XPS_MAX_AXES] = {0.0};
     
     if (pAxis == NULL) return MOTOR_AXIS_ERROR;
+    if (!pAxis->mutexId) {
+      PRINT(pAxis->logParam, MOTOR_ERROR, "motorAxisSetDouble[%d,%d]: invalid mutex ID. Call XPSConfigAxis first for initialization.\n", pAxis->card, pAxis->axis);
+      return MOTOR_AXIS_ERROR;
+    }
     else
     {
       if (epicsMutexLock( pAxis->mutexId ) == epicsMutexLockOK)
@@ -936,6 +940,11 @@ static int motorAxisMove(AXIS_HDL pAxis, double position, int relative,
     double deviceUnits;
 
     if (pAxis == NULL) return MOTOR_AXIS_ERROR;
+
+    if (!pAxis->mutexId) {
+      PRINT(pAxis->logParam, MOTOR_ERROR, "motorAxisMove[%d,%d]: invalid mutex ID. Call XPSConfigAxis first for initialization.\n", pAxis->card, pAxis->axis);
+      return MOTOR_AXIS_ERROR;
+    }
 
     PRINT(pAxis->logParam, FLOW, "Set card %d, axis %d move to %f, min vel=%f, max_vel=%f, accel=%f\n",
           pAxis->card, pAxis->axis, position, min_velocity, max_velocity, acceleration);


### PR DESCRIPTION
"While I was developing an EPICS application on the top of the motor
module, my application died for segmentation fault. The reason was my
mistake: I forgot to call XPSConfigAxis before I start to use that axis,
but it took time for me to find it out (e.g. compiled the motor module
and my application with debug option, running gdb, ...). So, I thought
it would be nice if an error message is shown in the console instead of
sudden death only with segmentation fault message, and the attached
patch does it."

Fixes #104 