### PR TITLE
Don't set "stop" field true if driver returns RA_PROBLEM true

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -3696,11 +3696,6 @@ static void process_motor_info(motorRecord * pmr, bool initcall)
         if (ls_active == true || msta.Bits.RA_PROBLEM)
         {
             clear_buttons(pmr);
-            if (msta.Bits.RA_PROBLEM)
-            {
-                pmr->stop = 1;
-                MARK(M_STOP);
-            }
         }
     }
     else

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -189,6 +189,7 @@ USAGE...        Motor Record Support.
  * .75 05-18-17 rls - Stop motor if URIP is Yes and RDBL read returns an error. 
  * .76 04-04-18 rls - If URIP is Yes and RDBL is inaccessible (e.g., CA server is down), do not start
  *                    a new target position move (sans Home search or Jog). 
+ * .78 08-21-18 kmp - Reverted .69 stop on RA_PROBLEM true.
  */                                                          
 
 #define VERSION 6.10


### PR DESCRIPTION
Partially reverts commit 303a9208e368ef07839afff67bac69e429af7332

Fixes issue #100:

> There have been multiple problems caused by the motor record sending a stop when the problem bit is set.
>
> One problem is discussed here:
> https://epics.anl.gov/tech-talk/2018/msg01338.php
>
> The commit that introduced the stop is 303a920. I vaguely recall the change being a workaround for less-than-idea behavior of a motor controller, but neither @rsluiter nor I remember which controller that was.
>
> Motor drivers should be modified to send the stop command when the condition that triggers the setting of the problem bit is detected, if needed.