### PR TITLE
Add field SPDB, "Set Point Dead Band"

### DIFF
--- a/docs/motorRecord.html
+++ b/docs/motorRecord.html
@@ -868,6 +868,14 @@ below.
     </td>
   </tr>
   <tr>
+    <td><a href="#Fields_motion">SPBD</a></td>
+    <td>R/W</td>
+    <td>Set Point Deadband (EGU)</td>
+    <td>DOUBLE</td>
+    <td><br>
+    </td>
+  </tr>
+  <tr>
     <td><a href="#Fields_link">RDBL</a></td>
     <td>R</td>
     <td>Readback Location</td>
@@ -1830,6 +1838,16 @@ below.
     performed (see RTRY).&nbsp;</td>
   </tr>
   <tr valign="top">
+    <td>SPBD</td>
+    <td>R/W</td>
+    <td>Set Point Deadband (EGU)</td>
+    <td>DOUBLE</td>
+    <td>Before the motor is commanded a move, a check is done if the move is to small.
+    It is to small when the distance is less the the step size defined in MRES.
+    When a bigger deadband is wanted than MRES, set the value into SPDB.
+    </td>
+  </tr>
+   <tr valign="top">
     <td>RTRY</td>
     <td>R/W</td>
     <td>Max retry count</td>

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -2239,6 +2239,18 @@ static RTN_STATUS do_work(motorRecord * pmr, CALLBACK_VALUE proc_ind)
             {
                 if (abs(npos - rpos) < 1)
                     too_small = true;
+                if (!too_small)
+                {
+                    double spdb = pmr->spdb;
+                    if (spdb > 0) {
+                        /* Don't move if new setpoint is within SPDB of DRBV */
+                        double drbv = pmr->drbv;
+                        double dval = pmr->dval;
+                        if (((dval - spdb) < drbv) && ((dval + spdb) > drbv)) {
+                            too_small = true;
+                        }
+                    }
+                }
             }
             else if (abs(npos - rpos) < rdbdpos)
                 too_small = true;

--- a/motorApp/MotorSrc/motorRecord.dbd
+++ b/motorApp/MotorSrc/motorRecord.dbd
@@ -415,6 +415,12 @@ recordtype(motor) {
                 special(SPC_MOD)
                 interest(1)
         }
+        field(SPDB,DBF_DOUBLE) {
+                prompt("Setpoint Deadband (EGU)")
+                promptgroup(GUI_COMMON)
+                special(SPC_MOD)
+                interest(1)
+        }
         field(RCNT,DBF_SHORT) {
                 prompt("Retry count")
                 special(SPC_NOMOD)


### PR DESCRIPTION
This is from Matthew Pearson, pearsonmr@ornl.gov

A number of users and staff have requested that the motor record have a
setpoint deadband field (eg. SPDB), which prevents any motion from
happening if the readback position is within SPDB.
Without a SPDB we have issues with motors moving unnecessarily.

For example, if the RBV is 0.001 and we set VAL to 0.0, if we have a
non-zero backlash correction then the motor will move unnecessarily
to take out backlash.
Even without backlash correction we often enable and disable the
drive amplifier for no good reason.

Currently the effective setpoint deadband is equal to MRES,
but this is often too small to be an effective setpoint deadband.

The new SPDB field would default to 0.0

The new code hooks into do_work():
When the new setpoint is within DPDB, set too_small and don't move.

The new code does not use snipptes like "abs(npos - rpos)", these
already produce warnings on 64 bit sytems.
abs() is declared to work on int, but we feed long values.
Simply compare the coordinates in engineering units.