### PR TITLE
Changed init function arguments to int

### DIFF
--- a/motorApp/AcsSrc/devMCB4B.cc
+++ b/motorApp/AcsSrc/devMCB4B.cc
@@ -52,7 +52,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* ----------------Create the dsets for devMCB4B----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long MCB4B_init(void *);
+STATIC long MCB4B_init(int);
 STATIC long MCB4B_init_record(void *);
 STATIC long MCB4B_start_trans(struct motorRecord *);
 STATIC RTN_STATUS MCB4B_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -105,13 +105,12 @@ static struct board_stat **MCB4B_cards;
 
 
 /* initialize device support for MCB4B stepper motor */
-STATIC long MCB4B_init(void *arg)
+STATIC long MCB4B_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
     Debug(5, "MCB4B_init: entry\n");
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &MCB4B_access;
         (drvtabptr->init)();

--- a/motorApp/AcsTech80Src/devSPiiPlus.cc
+++ b/motorApp/AcsTech80Src/devSPiiPlus.cc
@@ -50,7 +50,7 @@ extern struct driver_table SPiiPlus_access;
 
 /* ----------------Create the dsets for devSPiiPlus----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long SPiiPlus_init(void *);
+STATIC long SPiiPlus_init(int);
 STATIC long SPiiPlus_init_record(void *);
 STATIC long SPiiPlus_start_trans(struct motorRecord *);
 STATIC RTN_STATUS SPiiPlus_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -104,12 +104,11 @@ static struct board_stat **SPiiPlus_cards;
 
 
 /* initialize device support for SPiiPlus stepper motor */
-STATIC long SPiiPlus_init(void *arg)
+STATIC long SPiiPlus_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &SPiiPlus_access;
 	(drvtabptr->init)();

--- a/motorApp/AerotechSrc/devSoloist.cc
+++ b/motorApp/AerotechSrc/devSoloist.cc
@@ -51,7 +51,7 @@ extern struct driver_table Soloist_access;
 
 /* ----------------Create the dsets for devSoloist----------------- */
 static struct driver_table *drvtabptr;
-static long Soloist_init (void *);
+static long Soloist_init (int);
 static long Soloist_init_record (void *);
 static long Soloist_start_trans (struct motorRecord *);
 static RTN_STATUS Soloist_build_trans (motor_cmnd, double *,
@@ -108,12 +108,11 @@ static struct board_stat **Soloist_cards;
 
 
 // initialize device support for Soloist
-static long Soloist_init (void *arg)
+static long Soloist_init (int after)
 {
 	long rtnval;
-	int after = (arg == 0) ? 0 : 1;
 
-	if (after == 0)
+	if (!after)
 	{
 		drvtabptr = &Soloist_access;
 		(drvtabptr->init)();

--- a/motorApp/DeltaTauSrc/devPmac.cc
+++ b/motorApp/DeltaTauSrc/devPmac.cc
@@ -58,7 +58,7 @@ static RTN_STATUS Pmac_end_trans(struct motorRecord *);
 
 struct motor_dset devPmac =
 {
-    {8, NULL, (DEVSUPFUN) Pmac_init, Pmac_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) Pmac_init, (DEVSUPFUN) Pmac_init_record, NULL},
     motor_update_values,
     Pmac_start_trans,
     Pmac_build_trans,

--- a/motorApp/DeltaTauSrc/devPmac.cc
+++ b/motorApp/DeltaTauSrc/devPmac.cc
@@ -50,7 +50,7 @@ extern int Pmac_num_cards;
 extern struct driver_table Pmac_access;
 
 /* ----------------Create the dsets for devOMS----------------- */
-static long Pmac_init(void *);
+static long Pmac_init(int);
 static long Pmac_init_record(void *);
 static long Pmac_start_trans(struct motorRecord *);
 static RTN_STATUS Pmac_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -98,10 +98,8 @@ static msg_types Pmac_table[] = {
 static struct board_stat **Pmac_cards;
 static const char errmsg[] = {"\n\n!!!ERROR!!! - Oms driver uninitialized.\n"};
 
-static long Pmac_init(void *arg)
+static long Pmac_init(int after)
 {
-    int after = (arg == 0) ? 0 : 1;
-
     if (*(Pmac_access.init_indicator) == NO)
     {
 	errlogSevPrintf(errlogMinor, "%s", errmsg);

--- a/motorApp/DeltaTauSrc/devPmac.cc
+++ b/motorApp/DeltaTauSrc/devPmac.cc
@@ -58,7 +58,7 @@ static RTN_STATUS Pmac_end_trans(struct motorRecord *);
 
 struct motor_dset devPmac =
 {
-    {8, NULL, Pmac_init, Pmac_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) Pmac_init, Pmac_init_record, NULL},
     motor_update_values,
     Pmac_start_trans,
     Pmac_build_trans,

--- a/motorApp/FaulhaberSrc/devMCDC2805.cc
+++ b/motorApp/FaulhaberSrc/devMCDC2805.cc
@@ -50,7 +50,7 @@ extern struct driver_table MCDC2805_access;
 
 /* ----------------Create the dsets for devMCDC2805----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long MCDC2805_init(void *);
+STATIC long MCDC2805_init(int);
 STATIC long MCDC2805_init_record(void *);
 STATIC long MCDC2805_start_trans(struct motorRecord *);
 STATIC RTN_STATUS MCDC2805_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -104,12 +104,11 @@ static struct board_stat **MCDC2805_cards;
 
 
 /* initialize device support for MCDC2805 stepper motor */
-STATIC long MCDC2805_init(void *arg)
+STATIC long MCDC2805_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &MCDC2805_access;
 	(drvtabptr->init)();

--- a/motorApp/ImsSrc/devIM483PL.cc
+++ b/motorApp/ImsSrc/devIM483PL.cc
@@ -54,7 +54,7 @@ extern struct driver_table IM483PL_access;
 
 /* ----------------Create the dsets for devIM483PL----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long IM483PL_init(void *);
+STATIC long IM483PL_init(int);
 STATIC long IM483PL_init_record(void *);
 STATIC long IM483PL_start_trans(struct motorRecord *);
 STATIC RTN_STATUS IM483PL_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -108,12 +108,11 @@ static struct board_stat **IM483PL_cards;
 
 
 /* initialize device support for IM483PL stepper motor */
-STATIC long IM483PL_init(void *arg)
+STATIC long IM483PL_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &IM483PL_access;
 	(drvtabptr->init)();

--- a/motorApp/ImsSrc/devIM483SM.cc
+++ b/motorApp/ImsSrc/devIM483SM.cc
@@ -54,7 +54,7 @@ extern struct driver_table IM483SM_access;
 
 /* ----------------Create the dsets for devIM483SM----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long IM483SM_init(void *);
+STATIC long IM483SM_init(int);
 STATIC long IM483SM_init_record(void *);
 STATIC long IM483SM_start_trans(struct motorRecord *);
 STATIC RTN_STATUS IM483SM_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -108,12 +108,11 @@ static struct board_stat **IM483SM_cards;
 
 
 /* initialize device support for IM483SM stepper motor */
-STATIC long IM483SM_init(void *arg)
+STATIC long IM483SM_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &IM483SM_access;
 	(drvtabptr->init)();

--- a/motorApp/ImsSrc/devMDrive.cc
+++ b/motorApp/ImsSrc/devMDrive.cc
@@ -57,7 +57,7 @@ extern struct driver_table MDrive_access;
 
 /* ----------------Create the dsets for devMDrive----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long MDrive_init(void *);
+STATIC long MDrive_init(int);
 STATIC long MDrive_init_record(void *);
 STATIC long MDrive_start_trans(struct motorRecord *);
 STATIC RTN_STATUS MDrive_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -111,12 +111,11 @@ static struct board_stat **MDrive_cards;
 
 
 /* initialize device support for MDrive stepper motor */
-STATIC long MDrive_init(void *arg)
+STATIC long MDrive_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &MDrive_access;
 	(drvtabptr->init)();

--- a/motorApp/KohzuSrc/devSC800.cc
+++ b/motorApp/KohzuSrc/devSC800.cc
@@ -50,7 +50,7 @@ extern struct driver_table SC800_access;
 
 /* ----------------Create the dsets for devSC800----------------- */
 static struct driver_table *drvtabptr;
-static long SC800_init(void *);
+static long SC800_init(int);
 static long SC800_init_record(void *);
 static long SC800_start_trans(struct motorRecord *);
 static RTN_STATUS SC800_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -108,12 +108,11 @@ static struct board_stat **SC800_cards;
 
 
 /* initialize device support for SC800 stepper motor */
-static long SC800_init(void *arg)
+static long SC800_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
         drvtabptr = &SC800_access;
         (drvtabptr->init)();

--- a/motorApp/MXmotorSrc/devMXmotor.cc
+++ b/motorApp/MXmotorSrc/devMXmotor.cc
@@ -36,7 +36,7 @@ extern int MXmotor_num_cards;
 extern struct driver_table MXmotor_access;
 
 /* ----------------Create the dsets for devMXmotor----------------- */
-static long MXmotor_init(void *);
+static long MXmotor_init(int);
 static long MXmotor_init_record(void *);
 static long MXmotor_start_trans(struct motorRecord *);
 static RTN_STATUS MXmotor_build(motor_cmnd, double *, struct motorRecord *);
@@ -86,17 +86,15 @@ static struct board_stat **MXmotor_cards;
 static const char errmsg[] = {"\n\n!!!ERROR!!! - MX driver uninitialized.\n"};
 
 /* initialize device support for MX motor */
-static long MXmotor_init(void *after)
+static long MXmotor_init(int after)
 {
-    int before_after = (after == 0) ? 0 : 1;
-
     if (*(MXmotor_access.init_indicator) == NO)
     {
 	errlogSevPrintf(errlogMinor, "%s", errmsg);
     	return(ERROR);
     }
     else
-	return(motor_init_com(before_after, MXmotor_num_cards, &MXmotor_access,
+	return(motor_init_com(after, MXmotor_num_cards, &MXmotor_access,
 			      &MXmotor_cards));
 }
 

--- a/motorApp/MclennanSrc/devPM304.cc
+++ b/motorApp/MclennanSrc/devPM304.cc
@@ -61,7 +61,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* ----------------Create the dsets for devPM304----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long PM304_init(void *);
+STATIC long PM304_init(int);
 STATIC long PM304_init_record(void *);
 STATIC long PM304_start_trans(struct motorRecord *);
 STATIC RTN_STATUS PM304_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -113,12 +113,11 @@ static struct board_stat **PM304_cards;
 
 
 /* initialize device support for PM304 stepper motor */
-STATIC long PM304_init(void *arg)
+STATIC long PM304_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PM304_access;
         (drvtabptr->init)();

--- a/motorApp/MicosSrc/devMicos.cc
+++ b/motorApp/MicosSrc/devMicos.cc
@@ -46,7 +46,7 @@ extern struct driver_table Micos_access;
 
 /* ----------------Create the dsets for devMicos----------------- */
 static struct driver_table *drvtabptr;
-static long Micos_init(void *);
+static long Micos_init(int);
 static long Micos_init_record(void *);
 static long Micos_start_trans(struct motorRecord *);
 static RTN_STATUS Micos_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -97,13 +97,12 @@ static struct board_stat **Micos_cards;
 
 
 /* initialize device support for Micos DC motor */
-static long Micos_init(void *arg)
+static long Micos_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
     Debug(5, "Micos_init: entry\n");
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &Micos_access;
 	(drvtabptr->init)();

--- a/motorApp/MicroMoSrc/devMVP2001.cc
+++ b/motorApp/MicroMoSrc/devMVP2001.cc
@@ -104,7 +104,7 @@ extern struct driver_table MVP2001_access;
 
 /* ----------------Create the dsets for devMVP2001----------------- */
 static struct driver_table *drvtabptr;
-static long MVP2001_init(void *);
+static long MVP2001_init(int);
 static long MVP2001_init_record(void *);
 static long MVP2001_start_trans(struct motorRecord *);
 static RTN_STATUS MVP2001_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -158,10 +158,9 @@ static struct board_stat **MVP2001_cards;
 
 
 /* initialize device support for MVP2001 DC motor */
-static long MVP2001_init(void *arg)
+static long MVP2001_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
     drvtabptr = &MVP2001_access;
     rtnval = motor_init_com(after, *drvtabptr->cardcnt_ptr, drvtabptr, &MVP2001_cards);

--- a/motorApp/NewFocusSrc/devPMNC87xx.cc
+++ b/motorApp/NewFocusSrc/devPMNC87xx.cc
@@ -59,7 +59,7 @@ extern struct driver_table PMNC87xx_access;
 /* ----------------Create the dsets for devPMNC87xx----------------- */
 /* static long report(); */
 STATIC struct driver_table *drvtabptr;
-STATIC long PMNC87xx_init(void *);
+STATIC long PMNC87xx_init(int);
 STATIC long PMNC87xx_init_record(void *);
 STATIC long PMNC87xx_start_trans(struct motorRecord *);
 STATIC RTN_STATUS PMNC87xx_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -113,12 +113,11 @@ static struct board_stat **PMNC87xx_cards;
 
 
 /* initialize device support for PMNC87xx stepper motor */
-STATIC long PMNC87xx_init(void *arg)
+STATIC long PMNC87xx_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PMNC87xx_access;
 	(drvtabptr->init)();

--- a/motorApp/NewportSrc/devESP300.cc
+++ b/motorApp/NewportSrc/devESP300.cc
@@ -50,7 +50,7 @@ extern struct driver_table ESP300_access;
 /* ----------------Create the dsets for devESP300----------------- */
 /* static long report(); */
 static struct driver_table *drvtabptr;
-static long ESP300_init(void *);
+static long ESP300_init(int);
 static long ESP300_init_record(void *);
 static long ESP300_start_trans(struct motorRecord *);
 static RTN_STATUS ESP300_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -104,12 +104,11 @@ static struct board_stat **ESP300_cards;
 
 
 /* initialize device support for ESP300 stepper motor */
-static long ESP300_init(void *arg)
+static long ESP300_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &ESP300_access;
 	(drvtabptr->init)();

--- a/motorApp/NewportSrc/devMM3000.cc
+++ b/motorApp/NewportSrc/devMM3000.cc
@@ -56,7 +56,7 @@ extern struct driver_table MM3000_access;
 /* ----------------Create the dsets for devMM3000----------------- */
 /* static long report(); */
 STATIC struct driver_table *drvtabptr;
-STATIC long MM3000_init(void *);
+STATIC long MM3000_init(int);
 STATIC long MM3000_init_record(void *);
 STATIC long MM3000_start_trans(struct motorRecord *);
 STATIC RTN_STATUS MM3000_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -110,12 +110,11 @@ static struct board_stat **MM3000_cards;
 
 
 /* initialize device support for MM3000 stepper motor */
-STATIC long MM3000_init(void *arg)
+STATIC long MM3000_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &MM3000_access;
 	(drvtabptr->init)();

--- a/motorApp/NewportSrc/devMM4000.cc
+++ b/motorApp/NewportSrc/devMM4000.cc
@@ -57,7 +57,7 @@ extern struct driver_table MM4000_access;
 
 /* ----------------Create the dsets for devMM4000----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long MM4000_init(void *);
+STATIC long MM4000_init(int);
 STATIC long MM4000_init_record(void *);
 STATIC long MM4000_start_trans(struct motorRecord *);
 STATIC RTN_STATUS MM4000_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -111,12 +111,11 @@ static struct board_stat **MM4000_cards;
 
 
 /* initialize device support for MM4000 stepper motor */
-STATIC long MM4000_init(void *arg)
+STATIC long MM4000_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
         drvtabptr = &MM4000_access;
         (drvtabptr->init)();

--- a/motorApp/NewportSrc/devPM500.cc
+++ b/motorApp/NewportSrc/devPM500.cc
@@ -55,7 +55,7 @@ extern struct driver_table PM500_access;
 
 /* ----------------Create the dsets for devPM500----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long PM500_init(void *);
+STATIC long PM500_init(int);
 STATIC long PM500_init_record(void *);
 STATIC long PM500_start_trans(struct motorRecord *);
 STATIC RTN_STATUS PM500_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -111,12 +111,11 @@ static struct board_stat **PM500_cards;
 
 
 /* Initialize device support for PM500 controller. */
-STATIC long PM500_init(void *arg)
+STATIC long PM500_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PM500_access;
 	(drvtabptr->init)();

--- a/motorApp/OmsSrc/devMAXv.cc
+++ b/motorApp/OmsSrc/devMAXv.cc
@@ -52,7 +52,7 @@ static RTN_STATUS MAXv_end_trans(struct motorRecord *);
 
 struct motor_dset devMAXv =
 {
-    {8, NULL, MAXv_init, MAXv_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) MAXv_init, MAXv_init_record, NULL},
     motor_update_values,
     MAXv_start_trans,
     oms_build_trans,

--- a/motorApp/OmsSrc/devMAXv.cc
+++ b/motorApp/OmsSrc/devMAXv.cc
@@ -45,7 +45,7 @@ extern int MAXv_num_cards;
 extern struct driver_table MAXv_access;
 
 /* ----------------Create the dsets for devMAXv----------------- */
-static long MAXv_init(void *);
+static long MAXv_init(int);
 static long MAXv_init_record(void *);
 static long MAXv_start_trans(struct motorRecord *);
 static RTN_STATUS MAXv_end_trans(struct motorRecord *);
@@ -64,10 +64,8 @@ extern "C" {epicsExportAddress(dset,devMAXv);}
 static struct board_stat **MAXv_cards;
 static const char errmsg[] = {"\n\n!!!ERROR!!! - Oms MAXv driver uninitialized.\n"};
 
-static long MAXv_init(void *arg)
+static long MAXv_init(int after)
 {
-    int after = (arg == 0) ? 0 : 1;
-
     if (*(MAXv_access.init_indicator) == NO)
     {
 	errlogSevPrintf(errlogMinor, "%s", errmsg);

--- a/motorApp/OmsSrc/devMAXv.cc
+++ b/motorApp/OmsSrc/devMAXv.cc
@@ -52,7 +52,7 @@ static RTN_STATUS MAXv_end_trans(struct motorRecord *);
 
 struct motor_dset devMAXv =
 {
-    {8, NULL, (DEVSUPFUN) MAXv_init, MAXv_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) MAXv_init, (DEVSUPFUN) MAXv_init_record, NULL},
     motor_update_values,
     MAXv_start_trans,
     oms_build_trans,

--- a/motorApp/OmsSrc/devOms.cc
+++ b/motorApp/OmsSrc/devOms.cc
@@ -64,7 +64,7 @@ extern int oms44_num_cards;
 extern struct driver_table oms_access;
 
 /* ----------------Create the dsets for devOMS----------------- */
-static long oms_init(void *);
+static long oms_init(int);
 static long oms_init_record(void *);
 static long oms_start_trans(struct motorRecord *);
 static RTN_STATUS oms_end_trans(struct motorRecord *);
@@ -83,10 +83,8 @@ extern "C" {epicsExportAddress(dset,devOMS);}
 static struct board_stat **oms_cards;
 static const char errmsg[] = {"\n\n!!!ERROR!!! - Oms driver uninitialized.\n"};
 
-static long oms_init(void *arg)
+static long oms_init(int after)
 {
-    int after = (arg == 0) ? 0 : 1;
-
     if (*(oms_access.init_indicator) == NO)
     {
 	errlogSevPrintf(errlogMinor, "%s", errmsg);

--- a/motorApp/OmsSrc/devOms.cc
+++ b/motorApp/OmsSrc/devOms.cc
@@ -71,7 +71,7 @@ static RTN_STATUS oms_end_trans(struct motorRecord *);
 
 struct motor_dset devOMS =
 {
-    {8, NULL, (DEVSUPFUN) oms_init, oms_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) oms_init, (DEVSUPFUN) oms_init_record, NULL},
     motor_update_values,
     oms_start_trans,
     oms_build_trans,

--- a/motorApp/OmsSrc/devOms.cc
+++ b/motorApp/OmsSrc/devOms.cc
@@ -71,7 +71,7 @@ static RTN_STATUS oms_end_trans(struct motorRecord *);
 
 struct motor_dset devOMS =
 {
-    {8, NULL, oms_init, oms_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) oms_init, oms_init_record, NULL},
     motor_update_values,
     oms_start_trans,
     oms_build_trans,

--- a/motorApp/OmsSrc/devOms58.cc
+++ b/motorApp/OmsSrc/devOms58.cc
@@ -69,7 +69,7 @@ static RTN_STATUS oms_end_trans(struct motorRecord *);
 
 struct motor_dset devOms58 =
 {
-    {8, NULL, oms_init, oms_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) oms_init, oms_init_record, NULL},
     motor_update_values,
     oms_start_trans,
     oms_build_trans,

--- a/motorApp/OmsSrc/devOms58.cc
+++ b/motorApp/OmsSrc/devOms58.cc
@@ -69,7 +69,7 @@ static RTN_STATUS oms_end_trans(struct motorRecord *);
 
 struct motor_dset devOms58 =
 {
-    {8, NULL, (DEVSUPFUN) oms_init, oms_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) oms_init, (DEVSUPFUN) oms_init_record, NULL},
     motor_update_values,
     oms_start_trans,
     oms_build_trans,

--- a/motorApp/OmsSrc/devOms58.cc
+++ b/motorApp/OmsSrc/devOms58.cc
@@ -62,7 +62,7 @@ extern int oms58_num_cards;
 extern struct driver_table oms58_access;
 
 /* ----------------Create the dsets for devOMS----------------- */
-static long oms_init(void *);
+static long oms_init(int);
 static long oms_init_record(void *);
 static long oms_start_trans(struct motorRecord *);
 static RTN_STATUS oms_end_trans(struct motorRecord *);
@@ -81,10 +81,8 @@ extern "C" {epicsExportAddress(dset,devOms58);}
 static struct board_stat **oms_cards;
 static const char errmsg[] = {"\n\n!!!ERROR!!! - Oms58 driver uninitialized.\n"};
 
-static long oms_init(void *arg)
+static long oms_init(int after)
 {
-    int after = (arg == 0) ? 0 : 1;
-
     if (*(oms58_access.init_indicator) == NO)
     {
 	errlogSevPrintf(errlogMinor, "%s", errmsg);

--- a/motorApp/OmsSrc/devOmsPC68.cc
+++ b/motorApp/OmsSrc/devOmsPC68.cc
@@ -66,7 +66,7 @@ STATIC RTN_STATUS oms_end_trans(struct motorRecord *);
 
 struct motor_dset devOmsPC68 =
 {
-    {8, NULL, (DEVSUPFUN) oms_init, oms_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) oms_init, (DEVSUPFUN) oms_init_record, NULL},
     motor_update_values,
     oms_start_trans,
     oms_build_trans,

--- a/motorApp/OmsSrc/devOmsPC68.cc
+++ b/motorApp/OmsSrc/devOmsPC68.cc
@@ -59,7 +59,7 @@ extern int OmsPC68_num_cards;
 extern struct driver_table OmsPC68_access;
 
 /* ----------------Create the dsets for devOMS----------------- */
-STATIC long oms_init(void *);
+STATIC long oms_init(int);
 STATIC long oms_init_record(void *);
 STATIC long oms_start_trans(struct motorRecord *);
 STATIC RTN_STATUS oms_end_trans(struct motorRecord *);
@@ -80,10 +80,8 @@ STATIC const char errmsg[] = {"\n\n!!!ERROR!!! - OmsPC68 driver uninitialized.\n
 
 //__________________________________________________________________________________________
 
-STATIC long oms_init(void *arg)
+STATIC long oms_init(int after)
 {
-    int after = (arg == 0) ? 0 : 1;
-
     if (*(OmsPC68_access.init_indicator) == NO)
     {
         errlogSevPrintf(errlogMinor, "%s", errmsg);

--- a/motorApp/OmsSrc/devOmsPC68.cc
+++ b/motorApp/OmsSrc/devOmsPC68.cc
@@ -66,7 +66,7 @@ STATIC RTN_STATUS oms_end_trans(struct motorRecord *);
 
 struct motor_dset devOmsPC68 =
 {
-    {8, NULL, oms_init, oms_init_record, NULL},
+    {8, NULL, (DEVSUPFUN) oms_init, oms_init_record, NULL},
     motor_update_values,
     oms_start_trans,
     oms_build_trans,

--- a/motorApp/OrielSrc/devEMC18011.cc
+++ b/motorApp/OrielSrc/devEMC18011.cc
@@ -51,7 +51,7 @@ extern struct driver_table EMC18011_access;
 
 /* ----------------Create the dsets for devEMC18011----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long EMC18011_init(void *);
+STATIC long EMC18011_init(int);
 STATIC long EMC18011_init_record(void *);
 STATIC long EMC18011_start_trans(struct motorRecord *);
 STATIC RTN_STATUS EMC18011_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -105,12 +105,11 @@ static struct board_stat **EMC18011_cards;
 
 
 /* initialize device support for EMC18011 stepper motor */
-STATIC long EMC18011_init(void *arg)
+STATIC long EMC18011_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &EMC18011_access;
 	(drvtabptr->init)();

--- a/motorApp/PC6KSrc/devPC6K.cc
+++ b/motorApp/PC6KSrc/devPC6K.cc
@@ -50,7 +50,7 @@ extern struct driver_table PC6K_access;
 
 /* ----------------Create the dsets for devPC6K----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long PC6K_init(void *);
+STATIC long PC6K_init(int);
 STATIC long PC6K_init_record(void *);
 STATIC long PC6K_start_trans(struct motorRecord *);
 STATIC RTN_STATUS PC6K_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -104,12 +104,11 @@ static struct board_stat **PC6K_cards;
 
 
 /* initialize device support for PC6K stepper motor */
-STATIC long PC6K_init(void *arg)
+STATIC long PC6K_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PC6K_access;
 	(drvtabptr->init)();

--- a/motorApp/PiJenaSrc/devPIJEDS.cc
+++ b/motorApp/PiJenaSrc/devPIJEDS.cc
@@ -48,7 +48,7 @@ extern struct driver_table PIJEDS_access;
 
 /* ----------------Create the dsets for devPIJEDS----------------- */
 static struct driver_table *drvtabptr;
-static long PIJEDS_init(void *);
+static long PIJEDS_init(int);
 static long PIJEDS_init_record(void *);
 static long PIJEDS_start_trans(struct motorRecord *);
 static RTN_STATUS PIJEDS_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -102,12 +102,11 @@ static struct board_stat **PIJEDS_cards;
 
 
 /* initialize device support for PIJEDS stepper motor */
-static long PIJEDS_init(void *arg)
+static long PIJEDS_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIJEDS_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIC630.cc
+++ b/motorApp/PiSrc/devPIC630.cc
@@ -50,7 +50,7 @@ extern struct driver_table PIC630_access;
 
 /* ----------------Create the dsets for devPIC630----------------- */
 static struct driver_table *drvtabptr;
-static long PIC630_init(void *);
+static long PIC630_init(int);
 static long PIC630_init_record(void *);
 static long PIC630_start_trans(struct motorRecord *);
 static RTN_STATUS PIC630_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -102,13 +102,12 @@ static struct board_stat **PIC630_cards;
 
 
 /* initialize device support for PIC630 stepper motor */
-static long PIC630_init(void *arg)
+static long PIC630_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
     Debug(5, "PIC630_init: entry\n");
-    if (after == 0)
+    if (!after)
     {
         drvtabptr = &PIC630_access;
         (drvtabptr->init)();

--- a/motorApp/PiSrc/devPIC662.cc
+++ b/motorApp/PiSrc/devPIC662.cc
@@ -48,7 +48,7 @@ extern struct driver_table PIC662_access;
 
 /* ----------------Create the dsets for devPIC662----------------- */
 static struct driver_table *drvtabptr;
-static long PIC662_init(void *);
+static long PIC662_init(int);
 static long PIC662_init_record(void *);
 static long PIC662_start_trans(struct motorRecord *);
 static RTN_STATUS PIC662_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -102,12 +102,11 @@ static struct board_stat **PIC662_cards;
 
 
 /* initialize device support for PIC662 stepper motor */
-static long PIC662_init(void *arg)
+static long PIC662_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIC662_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIC663.cc
+++ b/motorApp/PiSrc/devPIC663.cc
@@ -27,7 +27,7 @@ extern struct driver_table PIC663_access;
 
 /* ----------------Create the dsets for devPIC663----------------- */
 static struct driver_table *drvtabptr;
-static long PIC663_init(void *);
+static long PIC663_init(int);
 static long PIC663_init_record(void *);
 static long PIC663_start_trans(struct motorRecord *);
 static RTN_STATUS PIC663_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -81,12 +81,11 @@ static struct board_stat **PIC663_cards;
 
 
 /* initialize device support for PIC663 servo motor */
-static long PIC663_init(void *arg)
+static long PIC663_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIC663_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIC844.cc
+++ b/motorApp/PiSrc/devPIC844.cc
@@ -48,7 +48,7 @@ extern struct driver_table PIC844_access;
 
 /* ----------------Create the dsets for devPIC844----------------- */
 static struct driver_table *drvtabptr;
-static long PIC844_init(void *);
+static long PIC844_init(int);
 static long PIC844_init_record(void *);
 static long PIC844_start_trans(struct motorRecord *);
 static RTN_STATUS PIC844_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -102,12 +102,11 @@ static struct board_stat **PIC844_cards;
 
 
 /* initialize device support for PIC844 stepper motor */
-static long PIC844_init(void *arg)
+static long PIC844_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIC844_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIC848.cc
+++ b/motorApp/PiSrc/devPIC848.cc
@@ -52,7 +52,7 @@ extern struct driver_table PIC848_access;
 
 /* ----------------Create the dsets for devPIC848----------------- */
 static struct driver_table *drvtabptr;
-static long PIC848_init(void *);
+static long PIC848_init(int);
 static long PIC848_init_record(void *);
 static long PIC848_start_trans(struct motorRecord *);
 static RTN_STATUS PIC848_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -106,12 +106,11 @@ static struct board_stat **PIC848_cards;
 
 
 /* initialize device support for PIC848 stepper motor */
-static long PIC848_init(void *arg)
+static long PIC848_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIC848_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIC862.cc
+++ b/motorApp/PiSrc/devPIC862.cc
@@ -31,7 +31,7 @@ extern struct driver_table PIC862_access;
 
 /* ----------------Create the dsets for devPIC862----------------- */
 static struct driver_table *drvtabptr;
-static long PIC862_init(void *);
+static long PIC862_init(int);
 static long PIC862_init_record(void *);
 static long PIC862_start_trans(struct motorRecord *);
 static RTN_STATUS PIC862_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -85,12 +85,11 @@ static struct board_stat **PIC862_cards;
 
 
 /* initialize device support for PIC862 servo motor */
-static long PIC862_init(void *arg)
+static long PIC862_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIC862_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIE516.cc
+++ b/motorApp/PiSrc/devPIE516.cc
@@ -49,7 +49,7 @@ extern struct driver_table PIE516_access;
 
 /* ----------------Create the dsets for devPIE516----------------- */
 static struct driver_table *drvtabptr;
-static long PIE516_init(void *);
+static long PIE516_init(int);
 static long PIE516_init_record(void *);
 static long PIE516_start_trans(struct motorRecord *);
 static RTN_STATUS PIE516_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -103,12 +103,11 @@ static struct board_stat **PIE516_cards;
 
 
 /* initialize device support for PIE516 stepper motor */
-static long PIE516_init(void *arg)
+static long PIE516_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIE516_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIE517.cc
+++ b/motorApp/PiSrc/devPIE517.cc
@@ -54,7 +54,7 @@ extern struct driver_table PIE517_access;
 
 /* ----------------Create the dsets for devPIE517----------------- */
 static struct driver_table *drvtabptr;
-static long PIE517_init(void *);
+static long PIE517_init(int);
 static long PIE517_init_record(void *);
 static long PIE517_start_trans(struct motorRecord *);
 static RTN_STATUS PIE517_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -108,12 +108,11 @@ static struct board_stat **PIE517_cards;
 
 
 /* initialize device support for PIE517 stepper motor */
-static long PIE517_init(void *arg)
+static long PIE517_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIE517_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIE710.cc
+++ b/motorApp/PiSrc/devPIE710.cc
@@ -49,7 +49,7 @@ extern struct driver_table PIE710_access;
 
 /* ----------------Create the dsets for devPIE710----------------- */
 static struct driver_table *drvtabptr;
-static long PIE710_init(void *);
+static long PIE710_init(int);
 static long PIE710_init_record(void *);
 static long PIE710_start_trans(struct motorRecord *);
 static RTN_STATUS PIE710_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -103,12 +103,11 @@ static struct board_stat **PIE710_cards;
 
 
 /* initialize device support for PIE710 stepper motor */
-static long PIE710_init(void *arg)
+static long PIE710_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIE710_access;
 	(drvtabptr->init)();

--- a/motorApp/PiSrc/devPIE816.cc
+++ b/motorApp/PiSrc/devPIE816.cc
@@ -52,7 +52,7 @@ extern struct driver_table PIE816_access;
 
 /* ----------------Create the dsets for devPIE816----------------- */
 static struct driver_table *drvtabptr;
-static long PIE816_init(void *);
+static long PIE816_init(int);
 static long PIE816_init_record(void *);
 static long PIE816_start_trans(struct motorRecord *);
 static RTN_STATUS PIE816_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -106,12 +106,11 @@ static struct board_stat **PIE816_cards;
 
 
 /* initialize device support for PIE816 stepper motor */
-static long PIE816_init(void *arg)
+static long PIE816_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &PIE816_access;
 	(drvtabptr->init)();

--- a/motorApp/SmartMotorSrc/devSmartMotor.cc
+++ b/motorApp/SmartMotorSrc/devSmartMotor.cc
@@ -70,7 +70,7 @@ extern struct driver_table SmartMotor_access;
 
 /* ----------------Create the dsets for devSmartMotor----------------- */
 static struct driver_table *drvtabptr;
-static long SmartMotor_init(void *);
+static long SmartMotor_init(int);
 static long SmartMotor_init_record(void *);
 static long SmartMotor_start_trans(struct motorRecord *);
 static RTN_STATUS SmartMotor_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -127,12 +127,11 @@ static struct board_stat **SmartMotor_cards;
 
 
 /* initialize device support for SmartMotor stepper motor */
-static long SmartMotor_init(void *arg)
+static long SmartMotor_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
         drvtabptr = &SmartMotor_access;
         (drvtabptr->init) ();

--- a/motorApp/SoftMotorSrc/devSoftAux.cc
+++ b/motorApp/SoftMotorSrc/devSoftAux.cc
@@ -91,9 +91,7 @@ STATIC void soft_rinp(struct event_handler_args args)
 
 long soft_init(int after)
 {
-    int before_after = (after == 0) ? 0 : 1;
-
-    if (before_after == 0)
+    if (!after)
     {
         epicsThreadId dbCaTask_tid;
         unsigned int soft_motor_priority;

--- a/motorApp/ThorLabsSrc/devMDT695.cc
+++ b/motorApp/ThorLabsSrc/devMDT695.cc
@@ -51,7 +51,7 @@ extern struct driver_table MDT695_access;
 
 /* ----------------Create the dsets for devMDT695----------------- */
 STATIC struct driver_table *drvtabptr;
-STATIC long MDT695_init(void *);
+STATIC long MDT695_init(int);
 STATIC long MDT695_init_record(void *);
 STATIC long MDT695_start_trans(struct motorRecord *);
 STATIC RTN_STATUS MDT695_build_trans(motor_cmnd, double *, struct motorRecord *);
@@ -105,12 +105,11 @@ static struct board_stat **MDT695_cards;
 
 
 /* initialize device support for MDT695 stepper motor */
-STATIC long MDT695_init(void *arg)
+STATIC long MDT695_init(int after)
 {
     long rtnval;
-    int after = (arg == 0) ? 0 : 1;
 
-    if (after == 0)
+    if (!after)
     {
 	drvtabptr = &MDT695_access;
 	(drvtabptr->init)();


### PR DESCRIPTION
- Changed init function arguments in model-1 drivers to int
- Simplified the init function logic related to "after"
- Cast the pointer to the init function as  DEVSUPFUN in the motor_dset structure

Fixes #111 
Fixes #115