### PR TITLE
Deprecated constructor "asynPortDriver" since asyn R4.32.0

### DIFF
--- a/motorApp/MotorSrc/asynMotorController.cpp
+++ b/motorApp/MotorSrc/asynMotorController.cpp
@@ -19,6 +19,14 @@
 #include "asynMotorController.h"
 #include "asynMotorAxis.h"
 
+#ifndef VERSION_INT
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#define MOTOR_ASYN_VERSION_INT VERSION_INT(ASYN_VERSION,ASYN_REVISION,ASYN_MODIFICATION,0)
+
+#define VERSION_INT_4_32 VERSION_INT(4,32,0,0)
+
 static const char *driverName = "asynMotorController";
 static void asynMotorPollerC(void *drvPvt);
 static void asynMotorMoveToHomeC(void *drvPvt);
@@ -34,12 +42,14 @@ asynMotorController::asynMotorController(const char *portName, int numAxes, int 
                                          int interfaceMask, int interruptMask,
                                          int asynFlags, int autoConnect, int priority, int stackSize)
 
-  : asynPortDriver(portName, numAxes, NUM_MOTOR_DRIVER_PARAMS+numParams,
+  : asynPortDriver(portName, numAxes,
+#if MOTOR_ASYN_VERSION_INT < VERSION_INT_4_32
+                   NUM_MOTOR_DRIVER_PARAMS+numParams,
+#endif
       interfaceMask | asynOctetMask | asynInt32Mask | asynFloat64Mask | asynFloat64ArrayMask | asynGenericPointerMask | asynDrvUserMask,
       interruptMask | asynOctetMask | asynInt32Mask | asynFloat64Mask | asynFloat64ArrayMask | asynGenericPointerMask,
       asynFlags, autoConnect, priority, stackSize),
     shuttingDown_(0), numAxes_(numAxes)
-
 {
   static const char *functionName = "asynMotorController";
 


### PR DESCRIPTION
The asyn module make the constructor
asynPortDriver::asynPortDriver(const char *portNameIn, int maxAddrIn,
           int paramTableSize, int interfaceMask, int interruptMask,
           int asynFlags, int autoConnect, int priority, int stackSize)

obsolete in R4.32.0, the more modern version should be used, which does
not have the parameter paramTableSize.
Using a modern version of asyn for the motor gives a compiler warning.
As I don't like compiler warnings, add a #ifdef construct to suppress it
for asyn > R4.32, and still allow to compile agains asyn >= R4.32