### PR TITLE
diff must be greater than RDBD for retry

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -974,7 +974,7 @@ static void maybeRetry(motorRecord * pmr)
     /* Commanded direction in user coordinates. */
     user_cdir = ((pmr->dir == motorDIR_Pos) == (pmr->mres >= 0)) ? pmr->cdir : !pmr->cdir;
 
-    if ((fabs(pmr->diff) >= pmr->rdbd) && !(pmr->hls && user_cdir) && !(pmr->lls && !user_cdir))
+    if ((fabs(pmr->diff) > pmr->rdbd) && !(pmr->hls && user_cdir) && !(pmr->lls && !user_cdir))
     {
         /* No, we're not close enough.  Try again. */
         Debug(1, "maybeRetry: not close enough; diff = %f\n", pmr->diff);


### PR DESCRIPTION
The documentation about the RDBD field says:
"When the motor has finished a complete motion, possibly including
 backlash takeout, the motor record will compare its current position
 with the desired position. If the magnitude of the difference
 is greater than RDBD, the motor will try again, as if the user had
 requested a move from the now current position to the desired position.
 Only a limited number of retries will be performed (see RTRY)."

The comparision in code code uses
"if ((fabs(pmr->diff) >= pmr->rdbd)"
which is too strict.
Loosen the if and use ">" instead of ">=".