### PR TITLE
Moved the polling from HXPAxis::poll to HXPController::poll

### DIFF
--- a/motorApp/NewportSrc/HXPDriver.h
+++ b/motorApp/NewportSrc/HXPDriver.h
@@ -77,7 +77,7 @@ private:
   double setpointPosition_;
   int axisStatus_;
   double mres_;
-  int moving_;
+  bool moving_;
   
 friend class HXPController;
 };
@@ -91,6 +91,7 @@ public:
   void report(FILE *fp, int level);
   HXPAxis* getAxis(asynUser *pasynUser);
   HXPAxis* getAxis(int axisNo);
+  asynStatus poll();
 
   /* These are the methods that are new to this class */
   int moveAll(HXPAxis* pAxis);
@@ -150,6 +151,10 @@ private:
   //int moveSocket_;
   char firmwareVersion_[100];
   char *axisNames_;
+  int groupStatus_;
+  double encoderPosition_[MAX_HXP_AXES];
+  double setpointPosition_[MAX_HXP_AXES];
+  bool moving_;
 
 friend class HXPAxis;
 };


### PR DESCRIPTION
Issue 124 description:

Older versions of the HXP firmware (v2.1.0 and earlier) are able to query the positions of the virtual axes independently using the virtual group names.  Newer versions of the firmware (confirmed with v3.1.0) return an error (-19: GroupName doesn't exist or unknown command).  Querying the positions of all six virtual axes simultaneously works on both v2.1.0 and v3.1.0.

Fixes #124 