### PR TITLE
Add field RSTM: Restore Mode

### DIFF
--- a/docs/motorRecord.html
+++ b/docs/motorRecord.html
@@ -890,6 +890,14 @@ below.
     </td>
   </tr>
   <tr>
+    <td><a href="#Fields_res">RSTM</a></td>
+    <td>R/W</td>
+    <td>Restory Mode</td>
+    <td>RECCHOICE</td>
+    <td>(0:"Never", 1:"Always", 2:"NearZero", 3:"Conditional")<br>
+    </td>
+  </tr>
+  <tr>
     <td><a href="#Fields_motion">SPDB</a></td>
     <td>R/W</td>
     <td>Set Point Deadband (EGU)</td>

--- a/motorApp/MotorSrc/motorRecord.dbd
+++ b/motorApp/MotorSrc/motorRecord.dbd
@@ -69,6 +69,13 @@ menu(motorRMOD) {
         choice(motorRMOD_I,"In-Position")
 }
 
+menu(motorRSTM) {
+        choice(motorRSTM_Never,       "Never")
+        choice(motorRSTM_Always,      "Always")
+        choice(motorRSTM_NearZero,    "NearZero")
+        choice(motorRSTM_Conditional, "Conditional")
+}
+
 include "menuOmsl.dbd"
 
 recordtype(motor) {
@@ -798,4 +805,11 @@ recordtype(motor) {
 		prompt("Ignore SET field")
 		interest(2)
 	}
+        field(RSTM,DBF_MENU) {
+                initial("NearZero")
+                prompt("Restore Mode")
+                promptgroup(GUI_COMMON)
+                interest(2)
+                menu(motorRSTM)
+        }
 }

--- a/motorApp/MotorSrc/motordevCom.cc
+++ b/motorApp/MotorSrc/motordevCom.cc
@@ -152,9 +152,7 @@ LOGIC...
         Set local encoder ratio to unity.
     ENDIF
 
-    Set Initialize position indicator based on (Use Relative Moves indicator == TRUE, OR,
-        [|DVAL| > RDBD, AND, MRES != 0, AND, the above |"get_axis_info()" position| < RDBD)]
-        [NOTE: |controller position| >= RDBD takes precedence over save/restore position].
+    Set Initialize position indicator based on the RSTM field
     Set Command Primitive Initialization string indicator based on (non-NULL "init"
         pointer, AND, non-zero string length.
 
@@ -189,7 +187,7 @@ motor_init_record_com(struct motorRecord *mr, int brdcnt, struct driver_table *t
     struct motor_dset *pdset = (struct motor_dset *) (mr->dset);
     struct board_stat *brdptr;
     int card, signal;
-    bool initEncoder, initPos, initString, initPID;
+    bool initEncoder, initPos = false, initString, initPID;
     struct motor_trans *ptrans;
     MOTOR_AXIS_QUERY axis_query;
     struct mess_node *motor_call;
@@ -210,7 +208,7 @@ motor_init_record_com(struct motorRecord *mr, int brdcnt, struct driver_table *t
 
     /* Semaphore on private to record field data transfers */
     ptrans->lock = new epicsEvent(epicsEventFull);
-                                                        
+
     motor_call = &(ptrans->motor_call);
 
     callbackSetCallback((void (*)(struct callbackPvt *)) motor_callback,
@@ -288,9 +286,26 @@ motor_init_record_com(struct motorRecord *mr, int brdcnt, struct driver_table *t
     else
         ep_mp[0] = ep_mp[1] = 1.0;
 
-    initPos = ((use_rel == true) ||
-               (fabs(mr->dval) > mr->rdbd && mr->mres != 0 && fabs(axis_query.position * mr->mres) < mr->rdbd)
-              ) ? true : false;
+    bool dval_non_zero_pos_near_zero = fabs(mr->dval) > mr->rdbd && mr->mres != 0 &&
+                                       fabs(axis_query.position * mr->mres) < mr->rdbd;
+    switch (mr->rstm) {
+        case motorRSTM_NearZero:
+            {
+                if (dval_non_zero_pos_near_zero)
+                    initPos = 1;
+            }
+            break;
+        case motorRSTM_Conditional:
+            {
+                if (dval_non_zero_pos_near_zero || use_rel)
+                    initPos = true;
+            }
+            break;
+        case motorRSTM_Always:
+          initPos = true;
+          break;
+    }
+
     /* Test for command primitive initialization string. */
     initString = (mr->init != NULL && strlen(mr->init)) ? true : false;
     /* Test for PID support. */


### PR DESCRIPTION
Partly revert the following commit:
  commit 3090983c313c57efdcd7c788ba234e775d300e06
  Author: Ron Sluiter <rsluiter@users.noreply.github.com>
  Date:   Wed Jul 29 15:50:23 2015 +0000
      Bug fix for target position (VAL/DVAL/RVAL) initialization error
      when the motor record is configured to do retries.
And from the release notes:

6) Kevin Peterson discovered an initialization bug when the motor record is
    configured to do retries. When configured to do retries, the motor
    record issues incremental rather than absolute moves. If the motor
    behaves badly (e.g., a piezo stiction motor) the controller's absolute
    step count can be far from its' absolute readback position. The motor
    record initialization logic that determines how the target positions
    are initialized at boot-up was not taking into consideration whether
    or not the motor record is configured to do retries, and therefore,
    whether or not absolute or incremental moves were issued by the motor
    record. With this release, if the motor record is configured to do
    retries, then the controller's absolute position is ignored (because
    the controller's absolute position was "corrupted" by retries) and the
    autosave/restore position is used to set the controllers position.

    Switching between retries on and off (relative vs. absolute moves)
    between reboots will cause unpredictable results and is not covered
    by this bug fix.

   Files modified: motor_init_record_com() in MotorSrc/motordevCom.cc
                   init_controller()       in MotorSrc/devMotorAsyn.c

Commit 3090983c improves the situation for setups where autosave is
used, and makes things worse for setups where autosave is not used.
When autosave is not used and the motor is configured to do retries,
the the DVAL field is loaded into the controller regardless.
And because DVAL is 0.0 at startup, the controller position is lost.

The first issue report is found here:
"Problem with R6-10 issue 6 fix - controller position can be lost on reboot"
https://github.com/epics-modules/motor/issues/85

And the we have another issue report here:
"IOC zeroes encoder on startup"
https://github.com/motorapp/Galil-3-0/issues/13

A possible way forward is discussed here:
"Add a field to the motor record to allow always restoring the
 autosaved position"
https://github.com/epics-modules/motor/issues/151

This commit add the "RSTM" field:
- 0 Disables restoring the autosaved position
- 1 Uses the same logic as motorRecord 6.9 (or older)
- 2 Restores the autosaved position regardless if the motor uses
    relative movements to do retries or not