### PR TITLE
travis/post-prepare.sh: Ignore return code of grep

### DIFF
--- a/.ci-local/travis/post-prepare.sh
+++ b/.ci-local/travis/post-prepare.sh
@@ -24,10 +24,10 @@ pwd
 sed -i -e "s|^\(SUPPORT=.*\)$|#\1|g" ./configure/RELEASE
 #
 echo -e "${ANSI_BLUE}Updated motor/configure/RELEASE${ANSI_RESET}"
-grep SUPPORT ./configure/RELEASE
+grep SUPPORT ./configure/RELEASE || :
 
 # Comment out SUPPORT from motorOms's RELEASE file
 sed -i -e "s|^\(SUPPORT=.*\)$|#\1|g" ./modules/motorOms/configure/RELEASE
 #
 echo -e "${ANSI_BLUE}Updated motor/modules/motorOms/configure/RELEASE${ANSI_RESET}"
-grep SUPPORT ./modules/motorOms/configure/RELEASE
+grep SUPPORT ./modules/motorOms/configure/RELEASE || :


### PR DESCRIPTION
When grepping for SUPPORT in the different files,
grep may fail, because "SUPPORT" is not present.
A failing grep will cause travis to fail.
Solution: Ugnore the exit code of grep.