### PR TITLE
Add shareLib.h

### DIFF
--- a/motorApp/MotorSrc/asynMotorAxis.h
+++ b/motorApp/MotorSrc/asynMotorAxis.h
@@ -10,6 +10,7 @@
 
 #include <epicsEvent.h>
 #include <epicsTypes.h>
+#include <shareLib.h>
 
 #ifdef __cplusplus
 #include <asynPortDriver.h>

--- a/motorApp/MotorSrc/asynMotorController.h
+++ b/motorApp/MotorSrc/asynMotorController.h
@@ -10,6 +10,7 @@
 
 #include <epicsEvent.h>
 #include <epicsTypes.h>
+#include <shareLib.h>
 
 #define MAX_CONTROLLER_STRING_SIZE 256
 #define DEFAULT_CONTROLLER_TIMEOUT 2.0


### PR DESCRIPTION
The new version of asyn does not use shareLib.h.  Thus we need to include shareLib.h in these files.
