### PR TITLE
motorRecord.cc: Improve both JOGF and JOGR active

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -3012,15 +3012,31 @@ pidcof:
     case motorRecordJOGF:
         if (pmr->jogf == 0)
             pmr->mip &= ~MIP_JOG_REQ;
-        else if (pmr->mip == MIP_DONE && !pmr->hls)
-            pmr->mip |= MIP_JOG_REQ;
+        else
+        {
+            if (pmr->jogr)
+            {
+                pmr->jogr = 0;
+                MARK_AUX(M_JOGR);
+            }
+            if (pmr->mip == MIP_DONE && !pmr->hls)
+                pmr->mip |= MIP_JOG_REQ;
+        }
         break;
 
     case motorRecordJOGR:
         if (pmr->jogr == 0)
             pmr->mip &= ~MIP_JOG_REQ;
-        else if (pmr->mip == MIP_DONE && !pmr->lls)
-            pmr->mip |= MIP_JOG_REQ;
+        else
+        {
+            if (pmr->jogf)
+            {
+                pmr->jogf = 0;
+                MARK_AUX(M_JOGF);
+            }
+            if (pmr->mip == MIP_DONE && !pmr->lls)
+               pmr->mip |= MIP_JOG_REQ;
+        }
         break;
 
     case motorRecordJVEL:


### PR DESCRIPTION
The situation when both JOGR and JOGF are active at the same time
was not handled very well:
  1) User set JOGR to 1
  2) User sets JOGF to 1 (without resetting JOGR)
  3) Motor stops
  4) Set JOGF to 1 again -> nothing happens
  5) Set JOGF=1 again -> motor moves backward

From the code we can see, that the motor is commanded backwards if
JOGR is set (pmr->jogr), regardless of JOGF.

My understanding is, that most GUIs don't allow JOGF and JOGR
to be active at the same time - problem solved.

Is there a good way to make the motorRecord more better-behaved
in this scenario?

I have some option in mind:
a) The latest JOGX command "wins".
   When JOGR is activated, JOGF is reset, if needed.
   And vice versa
b) The first JOGX command wins. The second one is ignored.
c) Both JOGR and JOGF are reset, motor is stopped.
d) The first JOGX is run to completion, and then the queued second
   request is executed.
e) Either a) or d) depending on the .NTM field.

In order to both keep the already complicated state machine simple
and match what the user probably expect, this patch implements a)

When JOGF is set to 1, then JOGR is set to 0 and vice versa