### PR TITLE
motordrvCom.h needs shareLib.h

### DIFF
--- a/motorApp/MotorSrc/motordrvCom.h
+++ b/motorApp/MotorSrc/motordrvCom.h
@@ -45,6 +45,7 @@ USAGE...	This file contains definitions and structures that
 #ifndef	INCmotordrvComh
 #define	INCmotordrvComh 1
 
+#include <shareLib.h>
 #include <callback.h>
 #include <epicsTypes.h>
 #include <epicsEvent.h>


### PR DESCRIPTION
We can't compile motor against this commit of EPICS base:
  commit 0f428ea3346d89719b03a6419319c85afb0fee13
  Author: Michael Davidsaver <mdavidsaver@gmail.com>
  Date:   Thu Apr 1 10:57:19 2021 -0700

      use DBCORE_API

Solution: Include <shareLib.h>