### PR TITLE
motorRecord: Reset UEIP to No if no encoder is present

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -3633,6 +3633,12 @@ static void process_motor_info(motorRecord * pmr, bool initcall)
 
     /* Calculate raw and dial readback values. */
     msta.All = pmr->msta;
+
+    if ((pmr->ueip == motorUEIP_Yes) && (!(msta.Bits.EA_PRESENT)))
+    {
+        pmr->ueip = motorUEIP_No;
+        db_post_events(pmr, &pmr->urip, DBE_VAL_LOG);
+    }
     if (pmr->ueip == motorUEIP_Yes)
     {
         /* An encoder is present and the user wants us to use it. */


### PR DESCRIPTION
When a database is loaded with UEIP=Yes and the controller says that there is no
encoder present, reset UEIP to False.