### PR TITLE
Remove uses of the deprecated register keyword

### DIFF
--- a/motorApp/MotorSrc/motordrvCom.cc
+++ b/motorApp/MotorSrc/motordrvCom.cc
@@ -211,8 +211,8 @@ static double query_axis(int card, struct driver_table *tabptr, epicsTime tick,
 
     for (index = 0; index < brdptr->total_axis; index++)
     {
-        register struct mess_info *motor_info;
-        register struct mess_node *motor_motion;
+        struct mess_info *motor_info;
+        struct mess_node *motor_motion;
         double delay = 0.0;
 
         motor_info = &(brdptr->motor_info[index]);


### PR DESCRIPTION
This keyword was deprecated in C++11 and removed from the language in C++17. clang 16 (or 15?) switched the default C++ standard to C++17, leading to compiler errors if you don't specify an older standard in `USR_CXXFLAGS`.