### PR TITLE
motorRecord.cc: Post ueip if reset to false when encoder missing

### DIFF
--- a/.github/workflows/ci-scripts-build-full.yml
+++ b/.github/workflows/ci-scripts-build-full.yml
@@ -108,22 +108,6 @@ jobs:
           #!  set: modules
           #!  name: "Ub-20 gcc-9 + RT-5.1 beatnik"
 
-          - os: ubuntu-18.04
-            cmp: gcc
-            configuration: default
-            base: "7.0"
-            set: modules
-            name: "Ub-18 gcc-7"
-
-          ### g++-8 not found
-          #!- os: ubuntu-18.04
-          #!  cmp: gcc-8
-          #!  utoolchain: true
-          #!  configuration: default
-          #!  base: "7.0"
-          #!  set: modules
-          #!  name: "Ub-18 gcc-8"
-
           #!- os: ubuntu-20.04
           #!  cmp: gcc-8
           #!  utoolchain: true

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Run main module tests
       run: python .ci/cue.py test
     - name: Upload tapfiles Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'

--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -3664,7 +3664,7 @@ static void process_motor_info(motorRecord * pmr, bool initcall)
     if ((pmr->ueip == motorUEIP_Yes) && (!(msta.Bits.EA_PRESENT)))
     {
         pmr->ueip = motorUEIP_No;
-        db_post_events(pmr, &pmr->urip, DBE_VAL_LOG);
+        db_post_events(pmr, &pmr->ueip, DBE_VAL_LOG);
     }
     if (pmr->ueip == motorUEIP_Yes)
     {


### PR DESCRIPTION
commit 24a53e660e213ae6a57dc4d6f5648bed895ef85e,
    "motorRecord: Reset UEIP to No if no encoder is present"
Seems to have introduced a typo:
When ueip is reset to false, because there is no encoder, then db_post_events(ueip) should be called, not urip.