### PR TITLE
motorRecord: prevent endless loop VAL-HOMF-VAL

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -1385,6 +1385,13 @@ static long process(dbCommon *arg)
                    !(pmr->mip & MIP_STOP)   &&
                    !(pmr->mip & MIP_JOG_STOP))
                 {
+                    if (pmr->mip == MIP_HOMF || pmr->mip == MIP_HOMR)
+                    {
+                        /* Bug fix: motor enters an infinite HOME loop
+                           in a sequence where VAL HOMF VAL is written */
+                        clear_buttons(pmr);
+                    }
+
                     pmr->mip = MIP_DONE;
                     /* Bug fix, record locks-up when BDST != 0, DLY != 0 and
                      * new target position before backlash correction move.*/


### PR DESCRIPTION
The following lead to an endless loop:
- move the motor by writing to the .VAL field
- while moving, home the motor using the HOMF field
- while still homing, write a different value to the VAL field.

The problem is that for "pmr->val != pmr->lval" the motorRecord is send into do_work() and a new HOME is started.

Solution:
Reset the HOMF and HOMR buttons.