### PR TITLE
Fix typos in motorRecord.html

### DIFF
--- a/docs/motorRecord.html
+++ b/docs/motorRecord.html
@@ -1923,9 +1923,9 @@ below.
     <td>R/W</td>
     <td>Set Point Deadband (EGU)</td>
     <td>DOUBLE</td>
-    <td>Before the motor is commanded a move, a check is done if the move is to small.
-    It is to small when the distance is less the the step size defined in MRES.
-    When a bigger deadband is wanted than MRES, set the value into SPDB.
+    <td>Before the motor is commanded to move, a check is done to see if the move is
+    too small. It is too small when the distance is less than the step size defined in
+    MRES. When a bigger deadband is wanted than MRES, set the value of SPDB.
     </td>
   </tr>
    <tr valign="top">


### PR DESCRIPTION
Fix typos in the `SPDB` field documentation in `motorRecord.html`.