### PR TITLE
motorRecord.html: Document MRES changes soft limits

### DIFF
--- a/docs/motorRecord.html
+++ b/docs/motorRecord.html
@@ -1534,8 +1534,9 @@ below.
       </p>
 
       <p>
-      Currently, changes to motor-resolution fields have no effect on the values of 
-      limit fields (although they should).&nbsp;
+      Changes to motor-resolution fields change the values of
+      limit fields since commit 3b5c71c412fd46 from May 2022.
+      This is included in R7-3.&nbsp;
       </p>
 
       <p>


### PR DESCRIPTION
Since commit 3b5c71c412fd46 from May 2022 the change of MRES does change the soft limits.
Technically speaking the introduced fields RHLM/RLLM keep their value. The fields DHLM/DLLM HLM/LLM are updated.
Document this.