### PR TITLE
Fixed RVEL bug

### DIFF
--- a/motorApp/MotorSrc/asynMotorAxis.cpp
+++ b/motorApp/MotorSrc/asynMotorAxis.cpp
@@ -288,7 +288,12 @@ asynStatus asynMotorAxis::setDoubleParam(int function, double value)
         statusChanged_ = 1;
         status_.encoderPosition = value;
     }
-  }  
+  } else if (function == pC_->motorVelocity_) {
+    if (value != status_.velocity) {
+        statusChanged_ = 1;
+        status_.velocity = value;
+    }
+  }
   // Call the base class method
   return pC_->setDoubleParam(axisNo_, function, value);
 }   


### PR DESCRIPTION
This PR fixes https://epics.anl.gov/tech-talk/2026/msg00212.php by writing the motor velocity into status_.velocity, where it is later read from when the motorRecord fields are populated.