### PR TITLE
asynMotor: Introduce motorActVelocity

### DIFF
--- a/motorApp/MotorSrc/asynMotorAxis.cpp
+++ b/motorApp/MotorSrc/asynMotorAxis.cpp
@@ -288,7 +288,7 @@ asynStatus asynMotorAxis::setDoubleParam(int function, double value)
         statusChanged_ = 1;
         status_.encoderPosition = value;
     }
-  } else if (function == pC_->motorVelocity_) {
+  } else if (function == pC_->motorActVelocity_) {
     if (value != status_.velocity) {
         statusChanged_ = 1;
         status_.velocity = value;

--- a/motorApp/MotorSrc/asynMotorController.cpp
+++ b/motorApp/MotorSrc/asynMotorController.cpp
@@ -60,6 +60,7 @@ asynMotorController::asynMotorController(const char *portName, int numAxes, int 
   createParam(motorHomeString,                   asynParamFloat64,    &motorHome_);
   createParam(motorStopString,                   asynParamInt32,      &motorStop_);
   createParam(motorVelocityString,               asynParamFloat64,    &motorVelocity_);
+  createParam(motorActVelocityString,            asynParamFloat64,    &motorActVelocity_);
   createParam(motorVelBaseString,                asynParamFloat64,    &motorVelBase_);
   createParam(motorAccelString,                  asynParamFloat64,    &motorAccel_);
   createParam(motorPositionString,               asynParamFloat64,    &motorPosition_);

--- a/motorApp/MotorSrc/asynMotorController.h
+++ b/motorApp/MotorSrc/asynMotorController.h
@@ -24,6 +24,7 @@
 #define motorMoveVelString              "MOTOR_MOVE_VEL"
 #define motorHomeString                 "MOTOR_HOME"
 #define motorStopString                 "MOTOR_STOP_AXIS"
+#define motorActVelocityString          "MOTOR_ACT_VELOCITY"
 #define motorVelocityString             "MOTOR_VELOCITY"
 #define motorVelBaseString              "MOTOR_VEL_BASE"
 #define motorAccelString                "MOTOR_ACCEL"
@@ -207,6 +208,7 @@ class epicsShareClass asynMotorController : public asynPortDriver {
   int motorHome_;
   int motorStop_;
   int motorVelocity_;
+  int motorActVelocity_;
   int motorVelBase_;
   int motorAccel_;
   int motorPosition_;


### PR DESCRIPTION
commit 11229ed6e56, Fixed RVEL bug, made a change to be able to set the .RVEL field in the motorRecord from a model 3 driver. However, this mixes motorVelocity_,
which is a setpoint changed with every movement, with an actual value, which changes while the motor is moving.
And goes to 0.0 when the motor has stopped.
Or stays at 0.0 when the motor refuse to start.
This may be caused by an interlock, limit switch, power off or others.

In short: Introduce a new asynParameter to store the value.

Compatiblity considarations:
Since the .RVEL field has never been working for an asynMotor, we don't expect any.

If needed, code can be adopted at compile time, with something like this:

   setDoubleParam(pC_->motorActVelocity_,
                  st_axis_status.fActVelocity);
 #endif