### PR TITLE
Motor record: change HVEL=0 case to default to VELO instead of VBAS

### DIFF
--- a/motorApp/MotorSrc/motorRecord.cc
+++ b/motorApp/MotorSrc/motorRecord.cc
@@ -4062,7 +4062,7 @@ static void check_speed_and_resolution(motorRecord * pmr)
 
     /* Sanity check on home velocity. */
     if (pmr->hvel == 0.0)
-        pmr->hvel = pmr->vbas;
+        pmr->hvel = pmr->velo;
     else
         range_check(pmr, &pmr->hvel, pmr->vbas, pmr->vmax);
 }


### PR DESCRIPTION
Unsure if this was intended behaviour or not, but I noticed that in the case of HVEL=0 (or the user didn't set HVEL) the record defaults to HVEL=VBAS - this is unexpected behaviour and results in much slower homing than expected.

I've changed motorRecord.cc to instead mirror VELO into HVEL. The modification is tested and functions correctly on a servo controller.